### PR TITLE
Really fixes for RN 0.40+

### DIFF
--- a/ios/RNZipArchive.h
+++ b/ios/RNZipArchive.h
@@ -7,11 +7,7 @@
 //
 
 
-#if __has_include("RCTBridgeModule.h")
-#import "RCTBridgeModule.h"
-#else
 #import <React/RCTBridgeModule.h>
-#endif
 #import "SSZipArchive/SSZipArchive.h"
 
 @interface RNZipArchive : NSObject<RCTBridgeModule, SSZipArchiveDelegate>

--- a/ios/RNZipArchive.m
+++ b/ios/RNZipArchive.m
@@ -8,12 +8,9 @@
 
 #import "RNZipArchive.h"
 
-#if __has_include("RCTBridge.h")
-#import "RCTBridge.h"
-#import "RCTEventDispatcher.h"
-#else
+#import <React/RCTBridge.h>
 #import <React/RCTEventDispatcher.h>
-#endif
+
 
 @implementation RNZipArchive
 
@@ -26,13 +23,13 @@ RCT_EXPORT_METHOD(unzip:(NSString *)zipPath
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 {
-
+    
     [self zipArchiveProgressEvent:0 total:1]; // force 0%
-
+    
     BOOL success = [SSZipArchive unzipFileAtPath:zipPath toDestination:destinationPath delegate:self];
-
+    
     [self zipArchiveProgressEvent:1 total:1]; // force 100%
-
+    
     if (success) {
         resolve(destinationPath);
     } else {
@@ -46,13 +43,13 @@ RCT_EXPORT_METHOD(zip:(NSString *)zipPath
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 {
-
+    
     [self zipArchiveProgressEvent:0 total:1]; // force 0%
-
+    
     BOOL success = [SSZipArchive createZipFileAtPath:destinationPath withContentsOfDirectory:zipPath];
-
+    
     [self zipArchiveProgressEvent:1 total:1]; // force 100%
-
+    
     if (success) {
         resolve(destinationPath);
     } else {
@@ -65,7 +62,7 @@ RCT_EXPORT_METHOD(zip:(NSString *)zipPath
     if (total == 0) {
         return;
     }
-
+    
     // TODO: should send the filename, just like the Android version
     [self.bridge.eventDispatcher sendAppEventWithName:@"zipArchiveProgressEvent" body:@{
                                                                                         @"progress": @( (float)loaded / (float)total )

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-zip-archive",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A little wrapper on ZipArchive for react-native",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The if/else wasn't working. This does, but drops support for >0.40.

This behavior is consistent with most native modules out there, instructing the user to just download a previous release of the module if needed.