### PR TITLE
updated podspec with the correct subfolder path

### DIFF
--- a/RNZipArchive.podspec
+++ b/RNZipArchive.podspec
@@ -23,8 +23,8 @@ Pod::Spec.new do |s|
   end
 
   s.subspec 'RNZASSZipArchive' do |ss|
-    ss.source_files = 'ios/RNZASSZipArchive/*.{h,m}', 'ios/RNZASSZipArchive/aes/*.{h,c}', 'ios/RNZASSZipArchive/minizip/*.{h,c}'
-    ss.private_header_files = 'ios/RNZASSZipArchive/*.h', 'ios/RNZASSZipArchive/aes/*.h', 'ios/RNZASSZipArchive/minizip/*.h'
+    ss.source_files = 'ios/SSZipArchive/*.{h,m}', 'ios/SSZipArchive/aes/*.{h,c}', 'ios/SSZipArchive/minizip/*.{h,c}'
+    ss.private_header_files = 'ios/SSZipArchive/*.h', 'ios/SSZipArchive/aes/*.h', 'ios/SSZipArchive/minizip/*.h'
   end
 
 end


### PR DESCRIPTION
Hi!

We were trying to use the podspec, but the name of the folder SSZipArchive was wrong, so fixed it & now we can compile the project with Cocoapods!:)
