### PR TITLE
Android progress events & unzip on background thread.

### DIFF
--- a/android/src/main/java/com/rnziparchive/RNZipArchiveModule.java
+++ b/android/src/main/java/com/rnziparchive/RNZipArchiveModule.java
@@ -242,7 +242,6 @@ public class RNZipArchiveModule extends ReactContextBaseJavaModule {
   @ReactMethod
   public void zip(String fileOrDirectory, String destDirectory, Promise promise) {
     List<String> filePaths = new ArrayList<>();
-    File file;
     try {
       File tmp = new File(fileOrDirectory);
       if (tmp.exists()) {
@@ -272,20 +271,22 @@ public class RNZipArchiveModule extends ReactContextBaseJavaModule {
     promise.resolve(destDirectory);
   }
 
-  private void zipStream(String[] files, String destFile, long totalSize) throws Exception {
+  private void zipStream(String[] files, String destFile, @SuppressWarnings("UnusedParameters") long totalSize) throws Exception {
     try {
       if (destFile.contains("/")) {
         File destDir = new File(destFile.substring(0, destFile.lastIndexOf("/")));
         if (!destDir.exists()) {
+          //noinspection ResultOfMethodCallIgnored
           destDir.mkdirs();
         }
       }
 
       if (new File(destFile).exists()) {
+        //noinspection ResultOfMethodCallIgnored
         new File(destFile).delete();
       }
 
-      BufferedInputStream origin = null;
+      BufferedInputStream origin;
       FileOutputStream dest = new FileOutputStream(destFile);
 
       ZipOutputStream out = new ZipOutputStream(new BufferedOutputStream(dest));
@@ -344,7 +345,7 @@ public class RNZipArchiveModule extends ReactContextBaseJavaModule {
     getReactApplicationContext().getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
             .emit(PROGRESS_EVENT_NAME, map);
   }
-  
+
   /**
    * Return the uncompressed size of the ZipFile (only works for files on disk, not in assets)
    *

--- a/android/src/main/java/com/rnziparchive/RNZipArchiveModule.java
+++ b/android/src/main/java/com/rnziparchive/RNZipArchiveModule.java
@@ -4,6 +4,7 @@ import android.content.res.AssetFileDescriptor;
 import android.util.Log;
 
 import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
@@ -19,9 +20,11 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Enumeration;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
 import java.util.zip.ZipInputStream;
 import java.util.zip.ZipOutputStream;
 
@@ -44,22 +47,95 @@ public class RNZipArchiveModule extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void unzip(String zipFilePath, String destDirectory, Promise promise) {
-    FileInputStream inputStream;
-    File file;
+
+    // Check the file exists
+    FileInputStream inputStream = null;
     try {
       inputStream = new FileInputStream(zipFilePath);
-      file = new File(zipFilePath);
+      new File(zipFilePath);
     } catch (FileNotFoundException | NullPointerException e) {
+      if (inputStream != null) {
+        try {
+          inputStream.close();
+        } catch (IOException ignored) {
+        }
+      }
       promise.reject(null, "Couldn't open file " + zipFilePath + ". ");
       return;
     }
+
     try {
-      unzipStream(zipFilePath, destDirectory, inputStream, file.length());
+      final long[] extractedBytes = {0};
+      final long totalUncompressedBytes = getUncompressedSize(zipFilePath);
+      final int[] lastPercentage = {0};
+
+      // Find the total uncompressed size of every file in the zip
+      File destDir = new File(destDirectory);
+      if (!destDir.exists()) {
+        destDir.mkdirs();
+      }
+
+      updateProgress(0, 1, zipFilePath); // force 0%
+
+      final ZipFile zipFile = new ZipFile(zipFilePath);
+      final Enumeration<? extends ZipEntry> entries = zipFile.entries();
+      Log.d(TAG, "Zip has " + zipFile.size() + " entries");
+      while (entries.hasMoreElements()) {
+        final ZipEntry entry = entries.nextElement();
+        if (entry.isDirectory()) continue;
+
+        StreamUtil.ProgressCallback cb = new StreamUtil.ProgressCallback() {
+          @Override
+          public void onCopyProgress(long bytesRead) {
+            extractedBytes[0] += bytesRead;
+
+            int lastTime = lastPercentage[0];
+            int percentDone = (int) ((double) extractedBytes[0] * 100 / (double) totalUncompressedBytes);
+
+            // update at most once per percent.
+            if (percentDone > lastTime) {
+              lastPercentage[0] = percentDone;
+              updateProgress(extractedBytes[0], totalUncompressedBytes, entry.getName());
+            }
+          }
+        };
+
+        File fout = new File(destDirectory, entry.getName());
+        if (!fout.exists()) {
+          (new File(fout.getParent())).mkdirs();
+        }
+        InputStream in = null;
+        BufferedOutputStream Bout = null;
+        try {
+          in = zipFile.getInputStream(entry);
+          Bout = new BufferedOutputStream(new FileOutputStream(fout));
+          StreamUtil.copy(in, Bout, cb);
+          Bout.close();
+          in.close();
+        } catch (IOException ex) {
+          if (in != null) {
+            try {
+              in.close();
+            } catch (Exception ignored) {
+            }
+          }
+          if (Bout != null) {
+            try {
+              Bout.close();
+            } catch (Exception ignored) {
+            }
+          }
+
+        }
+      }
+
+      zipFile.close();
+      updateProgress(1, 1, zipFilePath); // force 100%
+      promise.resolve(destDirectory);
     } catch (Exception ex) {
-      promise.reject(null, ex.getMessage());
-      return;
+      updateProgress(0, 1, zipFilePath); // force 0%
+      promise.reject(null, "Failed to extract file " + ex.getLocalizedMessage());
     }
-    promise.resolve(destDirectory);
   }
 
   @ReactMethod
@@ -251,5 +327,29 @@ public class RNZipArchiveModule extends ReactContextBaseJavaModule {
     bos.close();
 
     return size;
+  }
+
+  /**
+   * Return the uncompressed size of the ZipFile (only works for files on disk, not in assets)
+   *
+   * @return -1 on failure
+   */
+  private long getUncompressedSize(String zipFilePath) {
+    long totalSize = 0;
+    try {
+      ZipFile zipFile = new ZipFile(zipFilePath);
+      Enumeration<? extends ZipEntry> entries = zipFile.entries();
+      while (entries.hasMoreElements()) {
+        ZipEntry entry = entries.nextElement();
+        long size = entry.getSize();
+        if (size != -1) {
+          totalSize += size;
+        }
+      }
+      zipFile.close();
+    } catch (IOException ignored) {
+      return -1;
+    }
+    return totalSize;
   }
 }

--- a/android/src/main/java/com/rnziparchive/RNZipArchivePackage.java
+++ b/android/src/main/java/com/rnziparchive/RNZipArchivePackage.java
@@ -19,7 +19,7 @@ public class RNZipArchivePackage implements ReactPackage {
 
   @Override
   public List<Class<? extends JavaScriptModule>> createJSModules() {
-    return null;
+    return Collections.emptyList();
   }
 
   @Override

--- a/android/src/main/java/com/rnziparchive/RNZipArchivePackage.java
+++ b/android/src/main/java/com/rnziparchive/RNZipArchivePackage.java
@@ -18,6 +18,11 @@ public class RNZipArchivePackage implements ReactPackage {
   }
 
   @Override
+  public List<Class<? extends JavaScriptModule>> createJSModules() {
+    return null;
+  }
+
+  @Override
   public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
     return Arrays.<ViewManager>asList();
   }

--- a/android/src/main/java/com/rnziparchive/StreamUtil.java
+++ b/android/src/main/java/com/rnziparchive/StreamUtil.java
@@ -1,0 +1,39 @@
+package com.rnziparchive;
+
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import static com.facebook.common.internal.Preconditions.checkNotNull;
+
+public class StreamUtil {
+    private static final int BUF_SIZE = 0x1000; // 4K
+
+    public interface ProgressCallback {
+        // not the total - the actual number read since last time
+        void onCopyProgress(long bytesRead);
+    }
+
+    // https://stackoverflow.com/questions/4919690/how-to-read-one-stream-into-another
+    public static long copy(InputStream from, OutputStream to, ProgressCallback callback)
+            throws IOException {
+        checkNotNull(from);
+        checkNotNull(to);
+        byte[] buf = new byte[BUF_SIZE];
+        long total = 0;
+        while (true) {
+            int r = from.read(buf);
+            if (r == -1) {
+                break;
+            }
+            to.write(buf, 0, r);
+            total += r;
+
+            if (callback != null) {
+                callback.onCopyProgress(r);
+            }
+        }
+        return total;
+    }
+}


### PR DESCRIPTION
- Unzipping now takes place on a background thread (as recommended by the RN docs). RN docs also say that sending events from background threads is ok, which is why I do it here.
- The progress events will be fired at most 100 times (once per percent)
- When unzipping from a file, accurate progress can be measured as we can determine the uncompressed size of each file.
- When unzipping from assets, uncompressed sizes of files are not available, so we work around this by comparing the compressed size of the zip itself to the bytes extracted. This is (of course) less accurate.
- Sadly the two above features make the code a bit longer, as we can no longer share the unzipStream method between the assets and files.  Unzipping using a stream doesn't give you the uncompressed sizes (as explained above).
- I also fixed a couple of warnings in the Java code.

