### PR TITLE
Remove createJSModules @overide marker - RN 0.47 compatibility

### DIFF
--- a/android/src/main/java/com/rnziparchive/RNZipArchivePackage.java
+++ b/android/src/main/java/com/rnziparchive/RNZipArchivePackage.java
@@ -17,7 +17,7 @@ public class RNZipArchivePackage implements ReactPackage {
     return modules;
   }
 
-  @Override
+  // Deprecated RN 0.47
   public List<Class<? extends JavaScriptModule>> createJSModules() {
     return Collections.emptyList();
   }


### PR DESCRIPTION
[createJSModules is now not required on Android](https://github.com/facebook/react-native/commit/ce6fb337a146e6f261f2afb564aa19363774a7a8) from RN 0.47.
I actually can't build an app on RN 0.47 without removing this method/@overide marker.

There is similar issues :
- react-native-image-picker ([#649](https://github.com/react-community/react-native-image-picker/pull/649))
- react-native-contacts ([#205](https://github.com/rt2zz/react-native-contacts/pull/205))