### PR TITLE
Support projects that use React from cocoapods

### DIFF
--- a/ios/RNZipArchive.xcodeproj/project.pbxproj
+++ b/ios/RNZipArchive.xcodeproj/project.pbxproj
@@ -281,6 +281,7 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/../../react-native/React/**",
+					"../../../ios/Pods/Headers/Public/**",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
@@ -326,6 +327,7 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/../../react-native/React/**",
+					"../../../ios/Pods/Headers/Public/**",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MTL_ENABLE_DEBUG_INFO = NO;


### PR DESCRIPTION
apps that use cocoapods can't build directly without an adjustment to the header-search paths.

In particular expokit apps are affected (apps that are detached from expo). You will get a build error that some Header-Files are missing. 

The solution is to adjust the "Header Search Paths" and add a relative path *from* this library (which is in node_modules) to the Pods directory inside your app. See also https://docs.expo.io/versions/latest/guides/expokit.html#changing-native-dependencies

This PR adds this search path: `../../../ios/Pods/Headers/Public/**` This should usually work. I am not sure if it would be better to use $(SRCROOT) (i did not test it with that) or if there is a more generic solution to this problem.

Feedback welcome