### PR TITLE
added homepage attribute to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "unzip"
   ],
   "author": "Perry Poon <plrthink@gmail.com> (https://github.com/plrthink)",
+  "homepage": "https://github.com/mockingbot/react-native-zip-archive",
   "license": "MIT",
   "rnpm": {
     "ios": {


### PR DESCRIPTION
Pod installation fails without it.

[!] The `RNZipArchive` pod failed to validate due to 1 error:
    - ERROR | attributes: Missing required attribute `homepage`.