### PR TITLE
Wrong method signature

### DIFF
--- a/ios/RNZipArchive.m
+++ b/ios/RNZipArchive.m
@@ -63,7 +63,7 @@ RCT_EXPORT_METHOD(zip:(NSString *)from
     return dispatch_queue_create("com.mockingbot.ReactNative.ZipArchiveQueue", DISPATCH_QUEUE_SERIAL);
 }
 
-- (void)zipArchiveProgressEvent:(NSInteger)loaded total:(NSInteger)total filePath:(NSString *)filePath {
+- (void)zipArchiveProgressEvent:(unsigned long long)loaded total:(unsigned long long)total filePath:(NSString *)filePath {
     [self.bridge.eventDispatcher sendAppEventWithName:@"zipArchiveProgressEvent" body:@{
         @"progress": @((float)loaded / (float)total),
         @"filePath": filePath


### PR DESCRIPTION
On iOS 9 the method call crash because is not the same as the extended header class : `SSZipArchive/RNZASSZipArchive.h`