### PR TITLE
Android unzip: updateProgress call was not passing the zipFilePath

### DIFF
--- a/android/src/main/java/com/rnziparchive/RNZipArchiveModule.java
+++ b/android/src/main/java/com/rnziparchive/RNZipArchiveModule.java
@@ -101,7 +101,7 @@ public class RNZipArchiveModule extends ReactContextBaseJavaModule {
                 // update at most once per percent.
                 if (percentDone > lastTime) {
                   lastPercentage[0] = percentDone;
-                  updateProgress(extractedBytes[0], totalUncompressedBytes, entry.getName());
+                  updateProgress(extractedBytes[0], totalUncompressedBytes, zipFilePath);
                 }
               }
             };


### PR DESCRIPTION
In unzip method for Android, the zipFilePath was being filled with the entryName (thus, not allowing to know which zip file path corresponds the progress calculated)