### PR TITLE
Updating the package for compatibility with RN 0.56.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -11,12 +11,12 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion 26
+    buildToolsVersion "26.0.1"
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 22
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0"
     }


### PR DESCRIPTION
Without this fix, I had an error when building the project:
`<.......>
:react-native-zip-archive:mergeReleaseResources
:react-native-zip-archive:processReleaseManifest
:react-native-zip-archive:processReleaseResources
<path_to_app>\node_modules\react-native-zip-archive\android\build\intermediates\res\merged\release\values-v24\values-v24.xml:3: AAPT: Error retrieving parent for item: No resource found that matches the given name 'android:TextAppearance.Material.Widget.Button.Borderless.Colored'.

<path_to_app>\node_modules\react-native-zip-archive\android\build\intermediates\res\merged\release\values-v24\values-v24.xml:4: AAPT: Error retrieving parent for item: No resource found that matches the given name 'android:TextAppearance.Material.Widget.Button.Colored'.

<path_to_app>\node_modules\react-native-zip-archive\android\build\intermediates\res\merged\release\values-v26\values-v26.xml:15:21-54: AAPT: No resource found that matches the given name: attr 'android:keyboardNavigationCluster'.

<path_to_app>\node_modules\react-native-zip-archive\android\build\intermediates\res\merged\release\values-v24\values-v24.xml:3: error: Error retrieving parent for item: No resource found that matches the given name 'android:TextAppearance.Material.Widget.Button.Borderless.Colored'.

<path_to_app>\node_modules\react-native-zip-archive\android\build\intermediates\res\merged\release\values-v24\values-v24.xml:4: error: Error retrieving parent for item: No resource found that matches the given name 'android:TextAppearance.Material.Widget.Button.Colored'.

<path_to_app>\node_modules\react-native-zip-archive\android\build\intermediates\res\merged\release\values-v26\values-v26.xml:15: error: Error: No resource found that matches the given name: attr 'android:keyboardNavigationCluster'.

:react-native-zip-archive:processReleaseResources FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':react-native-zip-archive:processReleaseResources'.
> com.android.ide.common.process.ProcessException: Failed to execute aapt
<.......>`

You need targetSdkVersion 26 in your project's build.gradle to use this change.