### PR TITLE
Fixed conflict with Appodeal

### DIFF
--- a/ios/SSZipArchive/minizip/zip.c
+++ b/ios/SSZipArchive/minizip/zip.c
@@ -639,7 +639,7 @@ local ZPOS64_T zip64local_SearchCentralDir64(const zlib_filefunc64_32_def *pzlib
     return offset;
 }
 
-extern zipFile ZEXPORT zipOpen4(const void *pathname, int append, ZPOS64_T disk_size, zipcharpc *globalcomment,
+local zipFile ZEXPORT zipOpen4(const void *pathname, int append, ZPOS64_T disk_size, zipcharpc *globalcomment,
                                 zlib_filefunc64_32_def *pzlib_filefunc64_32_def)
 {
     zip64_internal ziinit;


### PR DESCRIPTION
duplicate symbol _zipOpen4 in:
    /ios/Pods/Appodeal/APDVungleAdapter.embeddedframework/VungleSDK.framework/VungleSDK(vungle_zip.o)