### PR TITLE
Make zip call non-blocking (Android)

### DIFF
--- a/android/src/main/java/com/rnziparchive/RNZipArchiveModule.java
+++ b/android/src/main/java/com/rnziparchive/RNZipArchiveModule.java
@@ -272,16 +272,11 @@ public class RNZipArchiveModule extends ReactContextBaseJavaModule {
 
     try {
       String[] filePathArray = filePaths.toArray(new String[filePaths.size()]);
-      zipStream(filePathArray, destDirectory, fromDirectory, filePaths.size(), promise);
+      new ZipTask(filePathArray, destDirectory, fromDirectory, promise, this).zip();
     } catch (Exception ex) {
       promise.reject(null, ex.getMessage());
       return;
     }
-  }
-
-  private void zipStream(String[] files, String destFile, String fromDirectory, @SuppressWarnings("UnusedParameters") long totalSize, Promise promise) throws Exception {
-    ZipTask task = new ZipTask(files, destFile, fromDirectory, promise, this);
-    task.zip();
   }
 
   private List<File> getSubFiles(File baseDir, boolean isContainFolder) {

--- a/android/src/main/java/com/rnziparchive/RNZipArchiveModule.java
+++ b/android/src/main/java/com/rnziparchive/RNZipArchiveModule.java
@@ -22,8 +22,6 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
-import java.util.Timer;
-import java.util.TimerTask;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import java.util.zip.ZipInputStream;
@@ -36,9 +34,6 @@ public class RNZipArchiveModule extends ReactContextBaseJavaModule {
   private static final String PROGRESS_EVENT_NAME = "zipArchiveProgressEvent";
   private static final String EVENT_KEY_FILENAME = "filePath";
   private static final String EVENT_KEY_PROGRESS = "progress";
-
-  private int inputFileSize;
-  private int bytesRead;
 
   public RNZipArchiveModule(ReactApplicationContext reactContext) {
     super(reactContext);
@@ -296,7 +291,7 @@ public class RNZipArchiveModule extends ReactContextBaseJavaModule {
     return fileList;
   }
 
-  void updateProgress(long extractedBytes, long totalSize, String zipFilePath) {
+  protected void updateProgress(long extractedBytes, long totalSize, String zipFilePath) {
     // Ensure progress can't overflow 1
     double progress = Math.min((double) extractedBytes / (double) totalSize, 1);
     Log.d(TAG, String.format("updateProgress: %.0f%%", progress * 100));

--- a/android/src/main/java/com/rnziparchive/ZipTask.java
+++ b/android/src/main/java/com/rnziparchive/ZipTask.java
@@ -1,0 +1,112 @@
+package com.rnziparchive;
+
+import android.util.Log;
+
+import com.facebook.react.bridge.Promise;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+public class ZipTask {
+  private final String destFile;
+  private final String[] files;
+  private final String fromDirectory;
+  private final Promise promise;
+  private static final int BUFFER_SIZE = 4096;
+
+  private int bytesRead = 0;
+  private long totalSize;
+  private RNZipArchiveModule cb;
+  private String threadError;
+
+  public ZipTask(String[] files, String destFile, String fromDirectory, Promise promise, RNZipArchiveModule cb) {
+    this.destFile = destFile;
+    this.files = files;
+    this.fromDirectory = fromDirectory;
+    this.promise = promise;
+    this.cb = cb;
+  }
+
+
+
+  public void zip() throws Exception {
+    Thread.UncaughtExceptionHandler h = new Thread.UncaughtExceptionHandler() {
+      public void uncaughtException(Thread th, Throwable ex) {
+        promise.reject(null , "Uncaught exception: " + ex);
+      }
+    };
+
+    Thread t = new Thread(new Runnable() {
+      public void run() {
+        try {
+          if (destFile.contains("/")) {
+            File destDir = new File(destFile.substring(0, destFile.lastIndexOf("/")));
+            if (!destDir.exists()) {
+              //noinspection ResultOfMethodCallIgnored
+              destDir.mkdirs();
+            }
+          }
+
+          if (new File(destFile).exists()) {
+            //noinspection ResultOfMethodCallIgnored
+            new File(destFile).delete();
+          }
+
+          BufferedInputStream origin;
+          FileOutputStream dest = new FileOutputStream(destFile);
+
+          ZipOutputStream out = new ZipOutputStream(new BufferedOutputStream(dest));
+
+          byte data[] = new byte[BUFFER_SIZE];
+
+          cb.updateProgress(0, 1, destFile); // force 0%
+          for (int i = 0; i < files.length; i++) {
+            String absoluteFilepath = files[i];
+
+            if (!new File(absoluteFilepath).isDirectory()) {
+              FileInputStream fi = new FileInputStream(absoluteFilepath);
+              String filename = absoluteFilepath.replace(fromDirectory, "");
+              ZipEntry entry = new ZipEntry(filename);
+              out.putNextEntry(entry);
+              origin = new BufferedInputStream(fi, BUFFER_SIZE);
+              totalSize = origin.available();
+              int count;
+
+              Timer timer = new Timer();
+              timer.scheduleAtFixedRate(new TimerTask() {
+                @Override
+                public void run() {
+                  cb.updateProgress(bytesRead, totalSize, destFile);
+                }
+              }, 200, 200);
+
+              while ((count = origin.read(data, 0, BUFFER_SIZE)) != -1) {
+                out.write(data, 0, count);
+                bytesRead += BUFFER_SIZE;
+              }
+              timer.cancel();
+              origin.close();
+            }
+          }
+          cb.updateProgress(1, 1, destFile); // force 100%
+          out.close();
+        } catch (Exception ex) {
+          ex.printStackTrace();
+          cb.updateProgress(0, 1, destFile); // force 0%
+          promise.reject(null, String.format("Couldn't zip %s", destFile));
+        }
+        promise.resolve(destFile);
+      }
+    });
+
+    t.setUncaughtExceptionHandler(h);
+    t.start();
+  }
+}

--- a/android/src/main/java/com/rnziparchive/ZipTask.java
+++ b/android/src/main/java/com/rnziparchive/ZipTask.java
@@ -34,12 +34,10 @@ public class ZipTask {
     this.cb = cb;
   }
 
-
-
-  public void zip() throws Exception {
+  public void zip() {
     Thread.UncaughtExceptionHandler h = new Thread.UncaughtExceptionHandler() {
       public void uncaughtException(Thread th, Throwable ex) {
-        promise.reject(null , "Uncaught exception: " + ex);
+        promise.reject(null , "Uncaught exception in ZipTask: " + ex);
       }
     };
 

--- a/android/src/main/java/com/rnziparchive/ZipTask.java
+++ b/android/src/main/java/com/rnziparchive/ZipTask.java
@@ -1,7 +1,5 @@
 package com.rnziparchive;
 
-import android.util.Log;
-
 import com.facebook.react.bridge.Promise;
 
 import java.io.BufferedInputStream;


### PR DESCRIPTION
A call of the zip function was blocking the UI on Android. The compression is now done on a separate thread so the main thread is not blocked anymore.

This PR also fixes the progress update while compressing files by retrieving the amount of bytes read from the source files 5 times per second.