### PR TITLE
Filename is incorrectly resolved on android

### DIFF
--- a/android/src/main/java/com/rnziparchive/ZipTask.java
+++ b/android/src/main/java/com/rnziparchive/ZipTask.java
@@ -5,6 +5,8 @@ import com.facebook.react.bridge.Promise;
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.util.Timer;
@@ -70,7 +72,7 @@ public class ZipTask {
 
             if (!new File(absoluteFilepath).isDirectory()) {
               FileInputStream fi = new FileInputStream(absoluteFilepath);
-              String filename = absoluteFilepath.replace(fromDirectory, "");
+              String filename = Paths.get(fromDirectory).relativize(Paths.get(absoluteFilepath)).toString();
               ZipEntry entry = new ZipEntry(filename);
               out.putNextEntry(entry);
               origin = new BufferedInputStream(fi, BUFFER_SIZE);


### PR DESCRIPTION
If you zip folder and omit slash at the end of the path 
```
zip('/var/whatever/test', '/result.zip');
```
Then internal paths in zip file will be absolute e.g. `/my/file.jpg`.
- If you run `unzip result.zip` it will complain that files have bad paths
- if you unzip docx file, modify and then zip back it will be corrupted because of absolute paths

That works fine on iOS