### PR TITLE
Update podspec to pull in SSZipArchive directly

### DIFF
--- a/RNZipArchive.podspec
+++ b/RNZipArchive.podspec
@@ -16,15 +16,11 @@ Pod::Spec.new do |s|
   s.library        = 'z'
 
   s.dependency 'React'
+  s.dependency 'SSZipArchive', '2.2.2'
 
   s.subspec 'Core' do |ss|
     ss.source_files = 'ios/*.{h,m}'
     ss.public_header_files = ['ios/RNZipArchive.h']
-  end
-
-  s.subspec 'SSZipArchive' do |ss|
-    ss.source_files = 'ios/SSZipArchive/*.{h,m}', 'ios/SSZipArchive/aes/*.{h,c}', 'ios/SSZipArchive/minizip/*.{h,c}'
-    ss.private_header_files = 'ios/SSZipArchive/*.h', 'ios/SSZipArchive/aes/*.h', 'ios/SSZipArchive/minizip/*.h'
   end
 
 end


### PR DESCRIPTION
This also eliminate the need to manually add libiconv and Security.framework.