### PR TITLE
feat: for 'unzip' method, add charset argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,8 +195,11 @@ Example
 ```js
 const sourcePath = `${DocumentDirectoryPath}/myFile.zip`
 const targetPath = DocumentDirectoryPath
+const charset = 'UTF-8' 
+// charset possible values: UTF-8, GBK, US-ASCII and so on. If none was passed, default value is UTF-8
 
-unzip(sourcePath, targetPath)
+
+unzip(sourcePath, targetPath, charset)
 .then((path) => {
   console.log(`unzip completed at ${path}`)
 })

--- a/android/src/main/java/com/rnziparchive/RNZipArchiveModule.java
+++ b/android/src/main/java/com/rnziparchive/RNZipArchiveModule.java
@@ -102,7 +102,7 @@ public class RNZipArchiveModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public void unzip(final String zipFilePath, final String destDirectory,final String charset, final Promise promise) {
+  public void unzip(final String zipFilePath, final String destDirectory, final String charset, final Promise promise) {
     new Thread(new Runnable() {
       @Override
       public void run() {
@@ -125,7 +125,7 @@ public class RNZipArchiveModule extends ReactContextBaseJavaModule {
         try {
           // Find the total uncompressed size of every file in the zip, so we can
           // get an accurate progress measurement
-          final long totalUncompressedBytes = getUncompressedSize(zipFilePath,charset);
+          final long totalUncompressedBytes = getUncompressedSize(zipFilePath, charset);
 
           File destDir = new File(destDirectory);
           if (!destDir.exists()) {
@@ -140,7 +140,7 @@ public class RNZipArchiveModule extends ReactContextBaseJavaModule {
           final long[] extractedBytes = {0};
           final int[] lastPercentage = {0};
 
-          final ZipFile zipFile = new ZipFile(zipFilePath,Charset.forName(charset));
+          final ZipFile zipFile = new ZipFile(zipFilePath, Charset.forName(charset));
           final Enumeration<? extends ZipEntry> entries = zipFile.entries();
           Log.d(TAG, "Zip has " + zipFile.size() + " entries");
           while (entries.hasMoreElements()) {
@@ -459,10 +459,10 @@ public class RNZipArchiveModule extends ReactContextBaseJavaModule {
    *
    * @return -1 on failure
    */
-  private long getUncompressedSize(String zipFilePath,String charset) {
+  private long getUncompressedSize(String zipFilePath, String charset) {
     long totalSize = 0;
     try {
-      ZipFile zipFile = new ZipFile(zipFilePath,Charset.forName(charset));
+      ZipFile zipFile = new ZipFile(zipFilePath, Charset.forName(charset));
       Enumeration<? extends ZipEntry> entries = zipFile.entries();
       while (entries.hasMoreElements()) {
         ZipEntry entry = entries.nextElement();

--- a/android/src/main/java/com/rnziparchive/RNZipArchiveModule.java
+++ b/android/src/main/java/com/rnziparchive/RNZipArchiveModule.java
@@ -33,6 +33,8 @@ import net.lingala.zip4j.model.FileHeader;
 import net.lingala.zip4j.model.ZipParameters;
 import net.lingala.zip4j.util.Zip4jConstants;
 
+import java.nio.charset.Charset;
+
 public class RNZipArchiveModule extends ReactContextBaseJavaModule {
   private static final String TAG = RNZipArchiveModule.class.getSimpleName();
 
@@ -100,7 +102,7 @@ public class RNZipArchiveModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public void unzip(final String zipFilePath, final String destDirectory, final Promise promise) {
+  public void unzip(final String zipFilePath, final String destDirectory,final String charset, final Promise promise) {
     new Thread(new Runnable() {
       @Override
       public void run() {
@@ -123,7 +125,7 @@ public class RNZipArchiveModule extends ReactContextBaseJavaModule {
         try {
           // Find the total uncompressed size of every file in the zip, so we can
           // get an accurate progress measurement
-          final long totalUncompressedBytes = getUncompressedSize(zipFilePath);
+          final long totalUncompressedBytes = getUncompressedSize(zipFilePath,charset);
 
           File destDir = new File(destDirectory);
           if (!destDir.exists()) {
@@ -138,7 +140,7 @@ public class RNZipArchiveModule extends ReactContextBaseJavaModule {
           final long[] extractedBytes = {0};
           final int[] lastPercentage = {0};
 
-          final ZipFile zipFile = new ZipFile(zipFilePath);
+          final ZipFile zipFile = new ZipFile(zipFilePath,Charset.forName(charset));
           final Enumeration<? extends ZipEntry> entries = zipFile.entries();
           Log.d(TAG, "Zip has " + zipFile.size() + " entries");
           while (entries.hasMoreElements()) {
@@ -457,10 +459,10 @@ public class RNZipArchiveModule extends ReactContextBaseJavaModule {
    *
    * @return -1 on failure
    */
-  private long getUncompressedSize(String zipFilePath) {
+  private long getUncompressedSize(String zipFilePath,String charset) {
     long totalSize = 0;
     try {
-      ZipFile zipFile = new ZipFile(zipFilePath);
+      ZipFile zipFile = new ZipFile(zipFilePath,Charset.forName(charset));
       Enumeration<? extends ZipEntry> entries = zipFile.entries();
       while (entries.hasMoreElements()) {
         ZipEntry entry = entries.nextElement();

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 declare module 'react-native-zip-archive' {
   import { NativeEventSubscription } from 'react-native';
   export function zip(source: string, target: string): Promise<string>;
-  export function unzip(source: string, target: string,charset?:string): Promise<string>;
+  export function unzip(source: string, target: string, charset?: string): Promise<string>;
   export function unzipWithPassword(assetPath: string, target: string, passowrd: string): Promise<string>;
   export function unzipAssets(assetPath: string, target: string): Promise<string>;
   export function subscribe(callback: ({ progress: number, filePath: string })): NativeEventSubscription;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 declare module 'react-native-zip-archive' {
   import { NativeEventSubscription } from 'react-native';
   export function zip(source: string, target: string): Promise<string>;
-  export function unzip(source: string, target: string): Promise<string>;
+  export function unzip(source: string, target: string,charset?:string): Promise<string>;
   export function unzipWithPassword(assetPath: string, target: string, passowrd: string): Promise<string>;
   export function unzipAssets(assetPath: string, target: string): Promise<string>;
   export function subscribe(callback: ({ progress: number, filePath: string })): NativeEventSubscription;

--- a/index.js
+++ b/index.js
@@ -9,8 +9,8 @@ const {
 
 const RNZipArchive = NativeModules.RNZipArchive
 
-export const unzip = (source, target) => {
-  return RNZipArchive.unzip(source, target)
+export const unzip = (source, target, charset = 'UTF-8') => {
+  return RNZipArchive.unzip(source, target, charset)
 }
 
 export const unzipWithPassword = (source, target, password) => {
@@ -39,6 +39,6 @@ export const unzipAssets = (source, target) => {
 
 export const subscribe = callback => {
   const emitter =
-    Platform.OS === 'ios' ? NativeAppEventEmitter : DeviceEventEmitter
+      Platform.OS === 'ios' ? NativeAppEventEmitter : DeviceEventEmitter
   return emitter.addListener('zipArchiveProgressEvent', callback)
 }

--- a/index.js
+++ b/index.js
@@ -39,6 +39,6 @@ export const unzipAssets = (source, target) => {
 
 export const subscribe = callback => {
   const emitter =
-      Platform.OS === 'ios' ? NativeAppEventEmitter : DeviceEventEmitter
+    Platform.OS === 'ios' ? NativeAppEventEmitter : DeviceEventEmitter
   return emitter.addListener('zipArchiveProgressEvent', callback)
 }

--- a/ios/RNZipArchive.m
+++ b/ios/RNZipArchive.m
@@ -31,6 +31,7 @@ RCT_EXPORT_METHOD(isPasswordProtected:(NSString *)file
 
 RCT_EXPORT_METHOD(unzip:(NSString *)from
                   destinationPath:(NSString *)destinationPath
+                  charset:(NSString *)charset
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
 


### PR DESCRIPTION
For Issue： Support for ZipFile constructor with Charset #149 
只是做了一个关于unzip方法的修改，增加了charset参数，在js中这个参数可省略，省略的的话编码默认为UTF-8。