### PR TITLE
fix assembleAndroidTest builds

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -15,6 +15,11 @@ android {
     compileSdkVersion rootProject.ext.compileSdkVersion
     buildToolsVersion rootProject.ext.buildToolsVersion
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
     defaultConfig {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion


### PR DESCRIPTION
Fixes an issue when building and running instrumented tests (e.g. Detox) for a React Native project on Android, the following build error was occurring:

```
* What went wrong:
Execution failed for task ':react-native-zip-archive:mergeExtDexDebugAndroidTest'.
> Could not resolve all files for configuration ':react-native-zip-archive:debugAndroidTestRuntimeClasspath'.
   > Failed to transform zip4j-2.6.4.jar (net.lingala.zip4j:zip4j:2.6.4) to match attributes {artifactType=android-dex, dexing-enable-desugaring=false, dexing-is-debuggable=true, dexing-min-sdk=23, org.gradle.category=library, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-runtime}.
      > Execution failed for DexingNoClasspathTransform: /Users/brent.kelly/.gradle/caches/modules-2/files-2.1/net.lingala.zip4j/zip4j/2.6.4/b1edd95127caa3a6c38b75b092b9c4a3ab91b835/zip4j-2.6.4.jar.
         > Error while dexing.
           The dependency contains Java 8 bytecode. Please enable desugaring by adding the following to build.gradle
           android {
               compileOptions {
                   sourceCompatibility 1.8
                   targetCompatibility 1.8
               }
           }
           See https://developer.android.com/studio/write/java8-support.html for details. Alternatively, increase the minSdkVersion to 26 or above.
```

If an Android library uses Java 8 language features then it must declare `compileOptions` in its `build.gradle`.

> ...each module that uses Java 8 language features (either in its source code or through dependencies), update the module's build.gradle file, as shown below:

https://developer.android.com/studio/write/java8-support#supported_features

I've seen similar issues crop up in other RN libraries e.g. https://github.com/negativetwelve/react-native-ux-cam/issues/104
