### PR TITLE
Update RNZipArchiveModule.java

### DIFF
--- a/android/src/main/java/com/rnziparchive/RNZipArchiveModule.java
+++ b/android/src/main/java/com/rnziparchive/RNZipArchiveModule.java
@@ -95,8 +95,8 @@ public class RNZipArchiveModule extends ReactContextBaseJavaModule {
                  throw new SecurityException(String.format("Found Zip Path Traversal Vulnerability with %s", canonicalPath));
             }
 
-            zipFile.extractFile(fileHeader, destDirectory);
             if (!fileHeader.isDirectory()) {
+               zipFile.extractFile(fileHeader, destDirectory);
               extractedFileNames.add(fileHeader.getFileName());
             }
             updateProgress(i + 1, totalFiles, zipFilePath);


### PR DESCRIPTION
解决解压带有密码的压缩包，解压文件夹中的文件，提示头文件找不到的问题。