### PR TITLE
chore(android): replaced jCenter with mavenCentral

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     repositories {
-        jcenter()
         google()
+        mavenCentral()
     }
 
     dependencies {


### PR DESCRIPTION
# Overview
jCenter will be offline in February 2022. I've updated the android project to use maven.

# Test Plan
I've tested the library on a personal project and it builds without issues.