### PR TITLE
Fix Android NativeEventEmitter warnings

### DIFF
--- a/android/src/main/java/com/rnziparchive/RNZipArchiveModule.java
+++ b/android/src/main/java/com/rnziparchive/RNZipArchiveModule.java
@@ -510,4 +510,14 @@ public class RNZipArchiveModule extends ReactContextBaseJavaModule {
     return sw.toString();
   }
 
+  @ReactMethod
+  public void addListener(String eventName) {
+    // Keep: Required for RN built in Event Emitter Calls.
+  }
+
+  @ReactMethod
+  public void removeListeners(Integer count) {
+    // Keep: Required for RN built in Event Emitter Calls.
+  }
+
 }


### PR DESCRIPTION
Adds method stubs required by React Native 0.65+, to address warnings that "new NativeEventEmitter was called with a non-null argument without the required [addListener/removeListeners] method"

Fixes #260