### PR TITLE
make getUncompressedSize public

### DIFF
--- a/android/src/main/java/com/rnziparchive/RNZipArchiveModule.java
+++ b/android/src/main/java/com/rnziparchive/RNZipArchiveModule.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.zip.ZipEntry;
+//import java.util.zip.ZipFile;
 import java.util.zip.ZipInputStream;
 
 import net.lingala.zip4j.exception.ZipException;
@@ -415,6 +416,12 @@ public class RNZipArchiveModule extends ReactContextBaseJavaModule {
             .emit(PROGRESS_EVENT_NAME, map);
   }
 
+  @ReactMethod
+  public void getUncompressedSize(String zipFilePath, String charset, final Promise promise) {
+    long totalSize = getUncompressedSize(zipFilePath, charset);
+    promise.resolve((double) totalSize);
+  }
+  
   /**
    * Return the uncompressed size of the ZipFile (only works for files on disk, not in assets)
    *

--- a/index.d.ts
+++ b/index.d.ts
@@ -12,4 +12,5 @@ declare module 'react-native-zip-archive' {
   export function unzipWithPassword(assetPath: string, target: string, password: string): Promise<string>;
   export function unzipAssets(assetPath: string, target: string): Promise<string>;
   export function subscribe(callback: ({ progress, filePath }: { progress: number, filePath: string }) => void): NativeEventSubscription;
+  export function getUncompressedSize(source: string, charset?: string): Promise<number>;
 }

--- a/index.js
+++ b/index.js
@@ -64,3 +64,7 @@ export const unzipAssets = (source, target) => {
 export const subscribe = (callback) => {
   return rnzaEmitter.addListener("zipArchiveProgressEvent", callback);
 };
+
+export const getUncompressedSize = (source, charset = "UTF-8") => {
+  return RNZipArchive.getUncompressedSize(normalizeFilePath(source), charset);
+};

--- a/ios/RNZipArchive.m
+++ b/ios/RNZipArchive.m
@@ -194,6 +194,22 @@ RCT_EXPORT_METHOD(zipFilesWithPassword:(NSArray<NSString *> *)from
     }
 }
 
+
+RCT_EXPORT_METHOD(getUncompressedSize:(NSString *)path
+                  charset:(NSString *)charset
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
+    NSError *error = nil;
+    NSNumber *wantedFileSize = [SSZipArchive payloadSizeForArchiveAtPath:path error:&error];
+
+    if (error == nil) {
+        resolve(wantedFileSize);
+    } else {
+//        reject(@"get_uncompressed_size_error", [error localizedDescription], error);
+        resolve(@-1);
+    }
+}
+
 - (dispatch_queue_t)methodQueue {
     return dispatch_queue_create("com.mockingbot.ReactNative.ZipArchiveQueue", DISPATCH_QUEUE_SERIAL);
 }


### PR DESCRIPTION
Hi,
I added a ReactMethod in android to get the function result and add a RCT_EXPORT_METHOD in ios to make the `getUncompressedSize` public, since my project needed that function.
This branch is based on my master branch since they are using net.lingala.zip4j.ZipFile.