### PR TITLE
Added instructions for compressing single file

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ zip(sourcePath, targetPath)
 
 **`zipWithPassword(source: string | string[], target: string, password: string, encryptionType: string): Promise<string>`**
 
-> zip source to target`
+> zip source to target
 
 ***NOTE: the string version of source is for folder, the string[] version is for file, so if you want to zip a single file, use zip([file]) instead of zip(file)***
 

--- a/README.md
+++ b/README.md
@@ -51,8 +51,6 @@ import { MainBundlePath, DocumentDirectoryPath } from 'react-native-fs'
 
 > zip source to target
 
-***NOTE: only support zip folder, not file entries***
-
 ***NOTE: the string version of source is for folder, the string[] version is for file, so if you want to zip a single file, use zip([file]) instead of zip(file)***
 
 Example
@@ -72,9 +70,7 @@ zip(sourcePath, targetPath)
 
 **`zipWithPassword(source: string | string[], target: string, password: string, encryptionType: string): Promise<string>`**
 
-> zip source to target
-
-***NOTE: only support zip folder, not file entries***
+> zip source to target`
 
 ***NOTE: the string version of source is for folder, the string[] version is for file, so if you want to zip a single file, use zip([file]) instead of zip(file)***
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ import { MainBundlePath, DocumentDirectoryPath } from 'react-native-fs'
 
 ***NOTE: only support zip folder, not file entries***
 
+***NOTE: the string version of source is for folder, the string[] version is for file, so you want to zip a single file, use zip([file]) instead of zip(file)***
+
 Example
 
 ```js
@@ -73,6 +75,8 @@ zip(sourcePath, targetPath)
 > zip source to target
 
 ***NOTE: only support zip folder, not file entries***
+
+***NOTE: the string version of source is for folder, the string[] version is for file, so you want to zip a single file, use zip([file]) instead of zip(file)***
 
 ***NOTE: encryptionType is not supported on iOS yet, so it would be igonred on that platform.***
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ import { MainBundlePath, DocumentDirectoryPath } from 'react-native-fs'
 
 ***NOTE: only support zip folder, not file entries***
 
-***NOTE: the string version of source is for folder, the string[] version is for file, so you want to zip a single file, use zip([file]) instead of zip(file)***
+***NOTE: the string version of source is for folder, the string[] version is for file, so if you want to zip a single file, use zip([file]) instead of zip(file)***
 
 Example
 
@@ -76,7 +76,7 @@ zip(sourcePath, targetPath)
 
 ***NOTE: only support zip folder, not file entries***
 
-***NOTE: the string version of source is for folder, the string[] version is for file, so you want to zip a single file, use zip([file]) instead of zip(file)***
+***NOTE: the string version of source is for folder, the string[] version is for file, so if you want to zip a single file, use zip([file]) instead of zip(file)***
 
 ***NOTE: encryptionType is not supported on iOS yet, so it would be igonred on that platform.***
 


### PR DESCRIPTION
I think a lot of people have had problem with not being able to compress a single file and then looking at the issue(https://github.com/mockingbot/react-native-zip-archive/issues/240#issuecomment-1381073257) to find a solution, and since the problem has been around for a long time, I think it would be nice to add a note to the readme to be friendly to new users ;)