### PR TITLE
chore(ios): Update SSZipArchive to 2.5.5

### DIFF
--- a/RNZipArchive.podspec
+++ b/RNZipArchive.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.preserve_paths = '*.js'
 
   s.dependency 'React-Core'
-  s.dependency 'SSZipArchive', '~>2.2'
+  s.dependency 'SSZipArchive', '~>2.5.5'
   s.compiler_flags = '-GCC_PREPROCESSOR_DEFINITIONS="HAVE_INTTYPES_H HAVE_PKCRYPT HAVE_STDINT_H HAVE_WZAES HAVE_ZLIB MZ_ZIP_NO_SIGNING $(inherited)"'
 
   s.subspec 'Core' do |ss|


### PR DESCRIPTION
Fix for this [issue](https://github.com/mockingbot/react-native-zip-archive/issues/302)