### PR TITLE
fix unzipAssets: Error: Asset file `...` could not be opened

### DIFF
--- a/android/src/main/java/com/rnziparchive/RNZipArchiveModule.java
+++ b/android/src/main/java/com/rnziparchive/RNZipArchiveModule.java
@@ -182,8 +182,7 @@ public class RNZipArchiveModule extends ReactContextBaseJavaModule {
 
         try {
           assetsInputStream = getReactApplicationContext().getAssets().open(assetsPath);
-          AssetFileDescriptor fileDescriptor = getReactApplicationContext().getAssets().openFd(assetsPath);
-          size = fileDescriptor.getLength();
+          size = -1;
         } catch (IOException e) {
           promise.reject(null, String.format("Asset file `%s` could not be opened", assetsPath));
           return;


### PR DESCRIPTION
This is just temporary solution for fixes #173 .

this openFd function is throwing an error:
[This file can not be opened as a file descriptor; it is probably compressed](https://stackoverflow.com/questions/6186866/java-io-filenotfoundexception-this-file-can-not-be-opened-as-a-file-descriptor)

We need to find another solution to get the file size.