### PR TITLE
Adds support for "content://" uri and progress during zip extraction on Android

### DIFF
--- a/android/src/main/java/com/rnziparchive/RNZipArchiveModule.java
+++ b/android/src/main/java/com/rnziparchive/RNZipArchiveModule.java
@@ -258,6 +258,9 @@ public class RNZipArchiveModule extends ReactContextBaseJavaModule {
 
               extractedBytes += entry.getCompressedSize();
 
+              // do not let the percentage go over 99% because we want it to hit 100% only when we are sure it's finished
+              if(extractedBytes > compressedSize*0.99) extractedBytes = (long) (compressedSize*0.99);
+
               updateProgress(extractedBytes, compressedSize, entry.getName());
             }
 

--- a/android/src/main/java/com/rnziparchive/RNZipArchiveModule.java
+++ b/android/src/main/java/com/rnziparchive/RNZipArchiveModule.java
@@ -36,6 +36,7 @@ import net.lingala.zip4j.model.enums.CompressionMethod;
 import net.lingala.zip4j.model.enums.CompressionLevel;
 import net.lingala.zip4j.model.enums.EncryptionMethod;
 import net.lingala.zip4j.model.enums.AesKeyStrength;
+import net.lingala.zip4j.progress.ProgressMonitor;
 
 import java.nio.charset.Charset;
 
@@ -67,7 +68,7 @@ public class RNZipArchiveModule extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void unzipWithPassword(final String zipFilePath, final String destDirectory,
-        final String password, final Promise promise) {
+                                final String password, final Promise promise) {
     new Thread(new Runnable() {
       @Override
       public void run() {
@@ -92,11 +93,11 @@ public class RNZipArchiveModule extends ReactContextBaseJavaModule {
             String destDirCanonicalPath = (new File(destDirectory).getCanonicalPath()) + File.separator;
 
             if (!canonicalPath.startsWith(destDirCanonicalPath)) {
-                 throw new SecurityException(String.format("Found Zip Path Traversal Vulnerability with %s", canonicalPath));
+              throw new SecurityException(String.format("Found Zip Path Traversal Vulnerability with %s", canonicalPath));
             }
 
             if (!fileHeader.isDirectory()) {
-               zipFile.extractFile(fileHeader, destDirectory);
+              zipFile.extractFile(fileHeader, destDirectory);
               extractedFileNames.add(fileHeader.getFileName());
             }
             updateProgress(i + 1, totalFiles, zipFilePath);
@@ -237,7 +238,7 @@ public class RNZipArchiveModule extends ReactContextBaseJavaModule {
               String destDirCanonicalPath = (new File(destDirectory).getCanonicalPath()) + File.separator;
 
               if (!canonicalPath.startsWith(destDirCanonicalPath)) {
-                   throw new SecurityException(String.format("Found Zip Path Traversal Vulnerability with %s", canonicalPath));
+                throw new SecurityException(String.format("Found Zip Path Traversal Vulnerability with %s", canonicalPath));
               }
 
               if (!fout.exists()) {
@@ -300,21 +301,21 @@ public class RNZipArchiveModule extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void zipFilesWithPassword(final ReadableArray files, final String destFile, final String password,
-                              String encryptionMethod, Promise promise) {
+                                   String encryptionMethod, Promise promise) {
     zipWithPassword(files.toArrayList(), destFile, password, encryptionMethod, promise);
   }
 
 
   @ReactMethod
   public void zipFolderWithPassword(final String folder, final String destFile, final String password,
-                                   String encryptionMethod, Promise promise) {
+                                    String encryptionMethod, Promise promise) {
     ArrayList<Object> folderAsArrayList = new ArrayList<>();
     folderAsArrayList.add(folder);
     zipWithPassword(folderAsArrayList, destFile, password, encryptionMethod, promise);
   }
 
   private void zipWithPassword(final ArrayList<Object> filesOrDirectory, final String destFile, final String password,
-      String encryptionMethod, Promise promise) {
+                               String encryptionMethod, Promise promise) {
     try{
 
       ZipParameters parameters = new ZipParameters();

--- a/android/src/main/java/com/rnziparchive/RNZipArchiveModule.java
+++ b/android/src/main/java/com/rnziparchive/RNZipArchiveModule.java
@@ -181,9 +181,18 @@ public class RNZipArchiveModule extends ReactContextBaseJavaModule {
         final long size;
 
         try {
-          assetsInputStream = getReactApplicationContext().getAssets().open(assetsPath);
-          AssetFileDescriptor fileDescriptor = getReactApplicationContext().getAssets().openFd(assetsPath);
-          size = fileDescriptor.getLength();
+          if(assetsPath.startsWith("content://")) {
+            var assetUri = Uri.parse(assetsPath);
+            var contentResolver = getReactApplicationContext().getContentResolver();
+
+            assetsInputStream = contentResolver.openInputStream(assetUri);
+            var fileDescriptor = contentResolver.openFileDescriptor(assetUri, "r");
+            size = fileDescriptor.getStatSize();
+          } else {
+            assetsInputStream = getReactApplicationContext().getAssets().open(assetsPath);
+            AssetFileDescriptor fileDescriptor = getReactApplicationContext().getAssets().openFd(assetsPath);
+            size = fileDescriptor.getLength();
+          }
         } catch (IOException e) {
           promise.reject(null, String.format("Asset file `%s` could not be opened", assetsPath));
           return;

--- a/android/src/main/java/com/rnziparchive/RNZipArchiveModule.java
+++ b/android/src/main/java/com/rnziparchive/RNZipArchiveModule.java
@@ -1,6 +1,7 @@
 package com.rnziparchive;
 
 import android.content.res.AssetFileDescriptor;
+import android.net.Uri;
 import android.os.Build;
 import android.util.Log;
 


### PR DESCRIPTION
- unzip now sends the progress event correctly on Android
- unzipAssets now supports "content://" uri obtained from file pickers