### PR TITLE
fix(android): cast compressionLevel to int in switch statement

### DIFF
--- a/android/src/main/java/com/rnziparchive/RNZipArchiveModule.java
+++ b/android/src/main/java/com/rnziparchive/RNZipArchiveModule.java
@@ -470,7 +470,7 @@ public class RNZipArchiveModule extends ReactContextBaseJavaModule {
   }
 
   private static CompressionLevel getCompressionLevel(double compressionLevel) {
-    switch (compressionLevel) {
+    switch ((int) compressionLevel) {
       case -1:
         return CompressionLevel.NORMAL;
       case 0:


### PR DESCRIPTION

Java does not support `switch` on `double` values — only `int`, `char`, `byte`, `short`, `String`, and enums are valid selector types.

`getCompressionLevel(double compressionLevel)` uses `switch (compressionLevel)` which fails to compile with newer JDK/AGP versions:

```
error: constant label of type int is not compatible with switch selector type double
```

The fix casts to `int` before the switch. This is safe since all valid values (`-1`, `0`–`9`) are whole numbers passed from JS.

Fixes #341