### PR TITLE
close zipFile before resolving promise

### DIFF
--- a/android/src/main/java/com/rnziparchive/RNZipArchiveModule.java
+++ b/android/src/main/java/com/rnziparchive/RNZipArchiveModule.java
@@ -403,11 +403,12 @@ public class RNZipArchiveModule extends NativeZipArchiveSpec {
             return;
           }
         }
-        updateProgress(1, 1, destFile); // force 100%
-        promise.resolve(destFile);
       } catch (Exception ex) {
         promise.reject("RNZipArchiveError", ex.getMessage());
+        return;
       }
+      updateProgress(1, 1, destFile); // force 100%
+      promise.resolve(destFile);
     });
   }
 


### PR DESCRIPTION
I noticed an occasional issue when using the zip file immediately after calling `zip(...)` that some of the data was all 0 bytes. I assume this is due to the zip not being closed and so some parts of the file were not flushed to disk. Adding the `.close()` call seems to have resolved the issue.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mockingbot/react-native-zip-archive/pull/355" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->