### PR TITLE
fix(e2e): use documented hide_error_dialogs ADB setting

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -205,11 +205,11 @@ jobs:
           disable-animations: true
           script: |
             # Expo's heavier UI can trigger a system-level ANR dialog on the
-            # low-memory GitHub Actions emulator. Disable ANR prompts before
-            # installing the app so Maestro is not blocked by emulator noise.
-            adb shell settings put secure show_anr_messages 0
-            adb shell settings put global anr_dialogs_disabled true
-            adb shell settings put global anr_show_background false
+            # low-memory GitHub Actions emulator. hide_error_dialogs is the
+            # documented AOSP global setting (Settings.Global.HIDE_ERROR_DIALOGS)
+            # used by CTS/Input ANR tests to suppress error dialogs on API 29+.
+            # Maestro still dismisses any dialog that slips through (_setup.yaml).
+            adb shell settings put global hide_error_dialogs 1
             adb install ${{ matrix.dir }}/android/app/build/outputs/apk/release/app-release.apk
             maestro test --env APP_ID="${{ matrix.bundle_id }}" .maestro/flows/ci-master.yaml
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Addresses [Devin review comment](https://github.com/mockingbot/react-native-zip-archive/pull/358#discussion_r3495968960) on PR #358.

## Issue

The three `adb shell settings put` commands added in #358 may be no-ops on API 29:

- `show_anr_messages` (secure) — not a documented AOSP key
- `anr_dialogs_disabled` (global, value `true`) — not documented; string `true` vs int `1` is also suspect
- `anr_show_background` (global) — not documented

`settings put` succeeds even for unrecognized keys, so these gave false confidence without actually suppressing dialogs.

## Fix

Use the documented AOSP setting instead:

```bash
adb shell settings put global hide_error_dialogs 1
```

This maps to `Settings.Global.HIDE_ERROR_DIALOGS`, which ActivityManager reads via `getInt()` to suppress system error dialogs (including ANR). It is used by Android CTS ANR tests and works on API 29+.

The Maestro repeat loop in `_setup.yaml` remains as the fallback for any dialog that still appears.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f168c-53e3-7ef9-9220-76db02e85cc7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f168c-53e3-7ef9-9220-76db02e85cc7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

