### PR TITLE
fix(android): skip symlink entries during extraction (#357)

### DIFF
--- a/android/src/main/java/com/rnziparchive/RNZipArchiveModule.java
+++ b/android/src/main/java/com/rnziparchive/RNZipArchiveModule.java
@@ -106,7 +106,7 @@ public class RNZipArchiveModule extends NativeZipArchiveSpec {
           ZipSecurity.validateExtractPath(destDirectory, fileHeader.getFileName());
 
           if (!fileHeader.isDirectory()) {
-            zipFile.extractFile(fileHeader, destDirectory);
+            zipFile.extractFile(fileHeader, destDirectory, ZipSecurity.createExtractParameters());
             extractedBytes += Math.max(fileHeader.getUncompressedSize(), 0);
           }
           updateProgress(extractedBytes, totalBytes, zipFilePath);
@@ -149,7 +149,7 @@ public class RNZipArchiveModule extends NativeZipArchiveSpec {
           ZipSecurity.validateExtractPath(destDirectory, fileHeader.getFileName());
 
           if (!fileHeader.isDirectory()) {
-            zipFile.extractFile(fileHeader, destDirectory);
+            zipFile.extractFile(fileHeader, destDirectory, ZipSecurity.createExtractParameters());
             extractedBytes += Math.max(fileHeader.getUncompressedSize(), 0);
           }
           updateProgress(extractedBytes, totalBytes, zipFilePath);

--- a/android/src/main/java/com/rnziparchive/ZipSecurity.java
+++ b/android/src/main/java/com/rnziparchive/ZipSecurity.java
@@ -3,6 +3,8 @@ package com.rnziparchive;
 import java.io.File;
 import java.io.IOException;
 
+import net.lingala.zip4j.model.UnzipParameters;
+
 /**
  * Validates zip extraction paths to prevent Zip Slip / path traversal attacks.
  */
@@ -10,6 +12,19 @@ public final class ZipSecurity {
 
   private ZipSecurity() {
     // utility class
+  }
+
+  /**
+   * Returns extraction parameters with symlink extraction disabled. zip4j enables symlink
+   * extraction by default but does not validate that a symlink's resolved target stays inside
+   * the destination directory, allowing archives to plant links escaping the extraction root
+   * (see issue #357). With symlinks disabled, zip4j skips symlink entries entirely, so nothing
+   * can escape the destination.
+   */
+  public static UnzipParameters createExtractParameters() {
+    UnzipParameters params = new UnzipParameters();
+    params.setExtractSymbolicLinks(false);
+    return params;
   }
 
   /**

--- a/android/src/test/java/com/rnziparchive/ZipSecurityTest.java
+++ b/android/src/test/java/com/rnziparchive/ZipSecurityTest.java
@@ -6,7 +6,14 @@ import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Base64;
 
+import net.lingala.zip4j.ZipFile;
+import net.lingala.zip4j.model.FileHeader;
+
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -53,5 +60,63 @@ public class ZipSecurityTest {
 
     // A directory name that contains ".." is not traversal as long as it stays inside dest
     ZipSecurity.validateExtractPath(dest.getAbsolutePath(), "foo..bar/baz.txt");
+  }
+
+  // Zip archive containing a single symlink entry: link_to_outside -> ../outside_target.txt
+  // (generated with `zip -y`, stored base64-encoded to keep the test hermetic)
+  private static final String SYMLINK_ZIP_BASE64 =
+      "UEsDBAoAAAAAAF1A9ly9NpyqFQAAABUAAAAPABwAbGlua190b19vdXRzaWRlVVQJAAOyCGBqsghganV4"
+      + "CwABBPUBAAAEFAAAAC4uL291dHNpZGVfdGFyZ2V0LnR4dFBLAQIeAwoAAAAAAF1A9ly9NpyqFQAAABUA"
+      + "AAAPABgAAAAAAAAAAADtoQAAAABsaW5rX3RvX291dHNpZGVVVAUAA7IIYGp1eAsAAQT1AQAABBQAAABQ"
+      + "SwUGAAAAAAEAAQBVAAAAXgAAAAAA";
+
+  private File writeSymlinkFixture() throws IOException {
+    File zip = temporaryFolder.newFile("symlink.zip");
+    Files.write(zip.toPath(), Base64.getDecoder().decode(SYMLINK_ZIP_BASE64));
+    return zip;
+  }
+
+  @Test
+  public void createExtractParameters_disablesSymlinkExtraction() {
+    assertFalse(ZipSecurity.createExtractParameters().isExtractSymbolicLinks());
+  }
+
+  @Test
+  public void extractWithZipSecurityParams_doesNotCreateSymlink() throws Exception {
+    File zip = writeSymlinkFixture();
+    File dest = temporaryFolder.newFolder("dest");
+
+    try (ZipFile zipFile = new ZipFile(zip)) {
+      for (FileHeader header : zipFile.getFileHeaders()) {
+        ZipSecurity.validateExtractPath(dest.getAbsolutePath(), header.getFileName());
+        zipFile.extractFile(header, dest.getAbsolutePath(), ZipSecurity.createExtractParameters());
+      }
+    }
+
+    Path link = dest.toPath().resolve("link_to_outside");
+    assertFalse("symlink entry must not be materialized (#357)",
+        Files.exists(link, java.nio.file.LinkOption.NOFOLLOW_LINKS));
+    assertFalse("nothing may appear outside dest",
+        Files.exists(dest.toPath().resolve("../outside_target.txt")));
+  }
+
+  @Test
+  public void extractWithDefaultParams_createsEscapingSymlink() throws Exception {
+    // Control test: proves the fixture exercises the vulnerable zip4j default path,
+    // i.e. the params from createExtractParameters() are what close the hole.
+    File zip = writeSymlinkFixture();
+    File dest = temporaryFolder.newFolder("dest");
+    // The symlink target must exist for toRealPath() resolution below
+    Files.write(temporaryFolder.getRoot().toPath().resolve("outside_target.txt"), new byte[0]);
+
+    try (ZipFile zipFile = new ZipFile(zip)) {
+      FileHeader header = zipFile.getFileHeaders().get(0);
+      zipFile.extractFile(header, dest.getAbsolutePath());
+    }
+
+    Path link = dest.toPath().resolve("link_to_outside");
+    assertTrue("control: zip4j defaults should create a symlink", Files.isSymbolicLink(link));
+    assertFalse("control: the default-created symlink escapes dest",
+        link.toRealPath().startsWith(dest.toPath().toRealPath()));
   }
 }


### PR DESCRIPTION
Fixes #357.

## Problem
zip4j 2.11.5 defaults `UnzipParameters.extractSymbolicLinks` to `true` and does not validate that a symlink's resolved target stays inside the destination directory. `unzip`/`unzipWithPassword` called `extractFile` without parameters, so a crafted archive entry like `link_to_outside -> ../outside_target.txt` would materialize a symlink escaping the extraction root. (The v9 `ZipSecurity` Zip Slip guard covers entry *names*, not symlink *targets*.)

## Fix
- `ZipSecurity.createExtractParameters()` returns `UnzipParameters` with `setExtractSymbolicLinks(false)`; both extraction call sites use it. With symlinks disabled, zip4j skips symlink entries entirely (verified against the 2.11.5 bytecode), so nothing can escape the destination.
- `unzipAssets` is unaffected by construction (manual stream copy, never creates symlinks).

## Tests
- `extractWithZipSecurityParams_doesNotCreateSymlink`: regression test using an embedded base64 fixture zip containing `link_to_outside -> ../outside_target.txt`; asserts nothing is materialized and nothing appears outside the destination.
- `extractWithDefaultParams_createsEscapingSymlink`: control test proving the fixture exercises the vulnerable zip4j default path.
- `createExtractParameters_disablesSymlinkExtraction`: sanity check on the params themselves.

`./gradlew :react-native-zip-archive:testDebugUnitTest` — 11/11 pass. `npx jest` — 27/27 pass.

Thanks @kimdu0 for the thorough report and repro.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mockingbot/react-native-zip-archive/pull/361" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->