### PR TITLE
fix(ios): add directory array items recursively in zip/zipWithPassword (#339)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ import { DocumentDirectoryPath } from 'react-native-fs'
 Zip a folder (string) or an array of files to the target path.
 
 - To zip a single file, pass it as an array: `zip([file], target)`.
+- Array items may also be directories: their contents are added recursively with entry paths relative to the listed directory (the directory's own name is not included). This behaves the same on Android and iOS, except that empty directories are preserved on Android only.
 - `compressionLevel` is ignored on iOS when the source is a file array. Use a directory source for custom compression on iOS.
 
 **Compression Level Constants:**
@@ -84,6 +85,7 @@ zip(sourcePath, targetPath)
 Zip with password protection.
 
 - To zip a single file, pass it as an array: `zipWithPassword([file], target, password)`.
+- Array items may also be directories: their contents are added recursively with entry paths relative to the listed directory (the directory's own name is not included). This behaves the same on Android and iOS, except that empty directories are preserved on Android only.
 - `compressionLevel` is ignored on iOS when the source is a file array.
 
 **Encryption Types:**

--- a/ios/RNZipArchive.mm
+++ b/ios/RNZipArchive.mm
@@ -155,6 +155,63 @@ destinationPath:(NSString *)destinationPath
     }
 }
 
+// Expands `paths` into (full path, entry name) pairs. Files keep their base
+// name; directory contents are added recursively with entry names relative to
+// the listed directory (e.g. "a.txt", "sub/b.txt"), matching Android's
+// zip(string[]) behavior (#339). Directory entries themselves are not written.
+// Returns nil if any path does not exist.
+- (NSArray<NSArray<NSString *> *> *)expandedZipEntries:(NSArray<NSString *> *)paths {
+    NSFileManager *fileManager = [[NSFileManager alloc] init];
+    NSMutableArray<NSArray<NSString *> *> *entries = [NSMutableArray array];
+    for (NSString *path in paths) {
+        BOOL isDirectory = NO;
+        if (![fileManager fileExistsAtPath:path isDirectory:&isDirectory]) {
+            return nil;
+        }
+        if (!isDirectory) {
+            [entries addObject:@[path, path.lastPathComponent]];
+            continue;
+        }
+        NSDirectoryEnumerator *enumerator = [fileManager enumeratorAtPath:path];
+        NSString *relativePath;
+        while ((relativePath = [enumerator nextObject])) {
+            NSString *fullPath = [path stringByAppendingPathComponent:relativePath];
+            BOOL childIsDirectory = NO;
+            [fileManager fileExistsAtPath:fullPath isDirectory:&childIsDirectory];
+            if (childIsDirectory) {
+                continue;
+            }
+            [entries addObject:@[fullPath, relativePath]];
+        }
+    }
+    return entries;
+}
+
+- (BOOL)writeZipEntriesToPath:(NSString *)destinationPath
+                        paths:(NSArray<NSString *> *)paths
+             compressionLevel:(int)compressionLevel
+                     password:(NSString *)password
+                          AES:(BOOL)aes {
+    NSArray<NSArray<NSString *> *> *entries = [self expandedZipEntries:paths];
+    if (entries == nil) {
+        return NO;
+    }
+    SSZipArchive *zipArchive = [[SSZipArchive alloc] initWithPath:destinationPath];
+    BOOL success = [zipArchive open];
+    if (success) {
+        NSUInteger total = entries.count, complete = 0;
+        for (NSArray<NSString *> *entry in entries) {
+            success &= [zipArchive writeFileAtPath:entry[0] withFileName:entry[1] compressionLevel:compressionLevel password:password AES:aes];
+            if (self.progressHandler) {
+                complete++;
+                self.progressHandler(complete, total);
+            }
+        }
+        success &= [zipArchive close];
+    }
+    return success;
+}
+
 - (void)zipFiles:(NSArray<NSString *> *)from
  destinationPath:(NSString *)destinationPath
 compressionLevel:(double)compressionLevel
@@ -167,7 +224,7 @@ compressionLevel:(double)compressionLevel
     BOOL success;
     [self setProgressHandler];
 
-    success = [SSZipArchive createZipFileAtPath:destinationPath withFilesAtPaths:from withPassword:nil progressHandler:self.progressHandler];
+    success = [self writeZipEntriesToPath:destinationPath paths:from compressionLevel:Z_DEFAULT_COMPRESSION password:nil AES:NO];
 
     self.progress = 1.0;
     [self zipArchiveProgressEvent:1 total:1]; // force 100%
@@ -226,8 +283,9 @@ compressionLevel:(double)compressionLevel
 
     BOOL success;
     [self setProgressHandler];
-    // Note: withFilesAtPaths doesn't have AES class method, using password only
-    success = [SSZipArchive createZipFileAtPath:destinationPath withFilesAtPaths:from withPassword:password progressHandler:self.progressHandler];
+    // Note: entries are written with AES:YES, matching the previous behavior of
+    // createZipFileAtPath:withFilesAtPaths: (which routes through AES:YES writes)
+    success = [self writeZipEntriesToPath:destinationPath paths:from compressionLevel:Z_DEFAULT_COMPRESSION password:password AES:YES];
 
     self.progress = 1.0;
     [self zipArchiveProgressEvent:1 total:1]; // force 100%


### PR DESCRIPTION
Fixes #339.

## Problem
`zip(string[])` behaved inconsistently across platforms when an array item is a **directory**:
- **Android** adds the directory's contents recursively, with entry names relative to the listed directory (`a.txt`, `sub/b.txt`).
- **iOS** passed the array straight to SSZipArchive's `createZipFileAtPath:withFilesAtPaths:`, which writes a directory as an empty entry — contents were silently dropped.

## Fix
iOS now expands the array itself before writing, using SSZipArchive's public instance API (`initWithPath:`/`open`/`writeFileAtPath:withFileName:.../`close`):
- file item → entry name is its base name (unchanged)
- directory item → each contained file is written with its path relative to the listed directory, matching Android's entry names

Applied to both `zipFiles` and `zipFilesWithPassword`.

## Preserved behaviors
- Per-entry progress events (total = expanded entry count)
- `zipFilesWithPassword` still writes with AES:YES, matching the previous `withFilesAtPaths:` code path
- `compressionLevel` remains ignored for file arrays on iOS (pre-existing; already documented)

## Residual divergence
Android preserves empty directories (zip4j folder entries); iOS skips directory entries. Documented in the README along with the aligned behavior.

## Verification
- playground-rn iOS app builds successfully (xcodebuild, Debug / iOS Simulator)
- `npx jest` — 27/27 pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mockingbot/react-native-zip-archive/pull/362" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->