### PR TITLE
docs+ci: Expo plugin, v7 upgrade path, SECURITY.md, SHA-pinned Actions

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -26,21 +26,21 @@ jobs:
             dir: playground-expo
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20
 
       - name: Setup Java
-        uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v4
+        uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v4.9.1
         with:
           distribution: 'zulu'
           java-version: '17'
 
       - name: Cache node_modules
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ${{ matrix.dir }}/node_modules
           key: ${{ runner.os }}-${{ matrix.app }}-node-${{ hashFiles(format('{0}/package.json', matrix.dir)) }}
@@ -56,7 +56,7 @@ jobs:
           fi
 
       - name: Cache Gradle
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: |
             ~/.gradle/caches

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -26,21 +26,21 @@ jobs:
             dir: playground-expo
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v4
         with:
           distribution: 'zulu'
           java-version: '17'
 
       - name: Cache node_modules
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ${{ matrix.dir }}/node_modules
           key: ${{ runner.os }}-${{ matrix.app }}-node-${{ hashFiles(format('{0}/package.json', matrix.dir)) }}
@@ -56,7 +56,7 @@ jobs:
           fi
 
       - name: Cache Gradle
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/.gradle/caches

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -37,10 +37,10 @@ jobs:
             runner: macos-26
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20
 
@@ -65,7 +65,7 @@ jobs:
           "$HOME/.maestro/bin/maestro" --version
 
       - name: Cache node_modules
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ${{ matrix.dir }}/node_modules
           key: ${{ runner.os }}-${{ matrix.app }}-node-${{ hashFiles(format('{0}/package.json', matrix.dir)) }}
@@ -81,7 +81,7 @@ jobs:
           fi
 
       - name: Cache CocoaPods
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ${{ matrix.dir }}/ios/Pods
           key: ${{ runner.os }}-${{ matrix.app }}-pods-${{ hashFiles(format('{0}/ios/Podfile.lock', matrix.dir)) }}
@@ -123,7 +123,7 @@ jobs:
 
       - name: Upload Maestro debug artifacts
         if: failure()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: maestro-debug-ios-${{ matrix.app }}
           path: ~/.maestro/tests/
@@ -138,7 +138,7 @@ jobs:
 
       - name: Upload crash logs artifact
         if: failure()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ios-crash-logs-${{ matrix.app }}
           path: crash-logs/
@@ -159,15 +159,15 @@ jobs:
             bundle_id: com.rnziparchive.playground.expo
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20
 
       - name: Setup Java
-        uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v4
+        uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v4.9.1
         with:
           distribution: 'zulu'
           java-version: '17'
@@ -193,7 +193,7 @@ jobs:
           "$HOME/.maestro/bin/maestro" --version
 
       - name: Cache node_modules
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ${{ matrix.dir }}/node_modules
           key: ${{ runner.os }}-${{ matrix.app }}-node-${{ hashFiles(format('{0}/package.json', matrix.dir)) }}
@@ -209,7 +209,7 @@ jobs:
           fi
 
       - name: Cache Gradle
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: |
             ~/.gradle/caches
@@ -223,7 +223,7 @@ jobs:
         run: ./gradlew :app:assembleRelease
 
       - name: Run E2E tests on Android emulator
-        uses: reactivecircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d # v2
+        uses: reactivecircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d # v2.38.0
         with:
           api-level: 29
           arch: x86_64
@@ -245,7 +245,7 @@ jobs:
 
       - name: Upload Maestro debug artifacts
         if: failure()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: maestro-debug-android-${{ matrix.app }}
           path: ~/.maestro/tests/

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -37,10 +37,10 @@ jobs:
             runner: macos-26
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
 
@@ -65,7 +65,7 @@ jobs:
           "$HOME/.maestro/bin/maestro" --version
 
       - name: Cache node_modules
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ${{ matrix.dir }}/node_modules
           key: ${{ runner.os }}-${{ matrix.app }}-node-${{ hashFiles(format('{0}/package.json', matrix.dir)) }}
@@ -81,7 +81,7 @@ jobs:
           fi
 
       - name: Cache CocoaPods
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ${{ matrix.dir }}/ios/Pods
           key: ${{ runner.os }}-${{ matrix.app }}-pods-${{ hashFiles(format('{0}/ios/Podfile.lock', matrix.dir)) }}
@@ -123,7 +123,7 @@ jobs:
 
       - name: Upload Maestro debug artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: maestro-debug-ios-${{ matrix.app }}
           path: ~/.maestro/tests/
@@ -138,7 +138,7 @@ jobs:
 
       - name: Upload crash logs artifact
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ios-crash-logs-${{ matrix.app }}
           path: crash-logs/
@@ -159,15 +159,15 @@ jobs:
             bundle_id: com.rnziparchive.playground.expo
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v4
         with:
           distribution: 'zulu'
           java-version: '17'
@@ -193,7 +193,7 @@ jobs:
           "$HOME/.maestro/bin/maestro" --version
 
       - name: Cache node_modules
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ${{ matrix.dir }}/node_modules
           key: ${{ runner.os }}-${{ matrix.app }}-node-${{ hashFiles(format('{0}/package.json', matrix.dir)) }}
@@ -209,7 +209,7 @@ jobs:
           fi
 
       - name: Cache Gradle
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/.gradle/caches
@@ -223,7 +223,7 @@ jobs:
         run: ./gradlew :app:assembleRelease
 
       - name: Run E2E tests on Android emulator
-        uses: reactivecircus/android-emulator-runner@v2
+        uses: reactivecircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d # v2
         with:
           api-level: 29
           arch: x86_64
@@ -245,7 +245,7 @@ jobs:
 
       - name: Upload Maestro debug artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: maestro-debug-android-${{ matrix.app }}
           path: ~/.maestro/tests/

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -32,15 +32,15 @@ jobs:
             runner: macos-26
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20
 
       - name: Cache node_modules
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ${{ matrix.dir }}/node_modules
           key: ${{ runner.os }}-${{ matrix.app }}-node-${{ hashFiles(format('{0}/package.json', matrix.dir)) }}
@@ -56,7 +56,7 @@ jobs:
           fi
 
       - name: Cache CocoaPods
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ${{ matrix.dir }}/ios/Pods
           key: ${{ runner.os }}-${{ matrix.app }}-pods-${{ hashFiles(format('{0}/ios/Podfile.lock', matrix.dir)) }}

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -32,15 +32,15 @@ jobs:
             runner: macos-26
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
 
       - name: Cache node_modules
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ${{ matrix.dir }}/node_modules
           key: ${{ runner.os }}-${{ matrix.app }}-node-${{ hashFiles(format('{0}/package.json', matrix.dir)) }}
@@ -56,7 +56,7 @@ jobs:
           fi
 
       - name: Cache CocoaPods
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ${{ matrix.dir }}/ios/Pods
           key: ${{ runner.os }}-${{ matrix.app }}-pods-${{ hashFiles(format('{0}/ios/Podfile.lock', matrix.dir)) }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,13 +9,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
     - name: Set up Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
       with:
         node-version: 20
     - name: Publish if version has been updated
-      uses: pascalgn/npm-publish-action@1.3.9
+      uses: pascalgn/npm-publish-action@374314eadce0ca5353387666469a949f69414752 # 1.3.9
       with: # All of theses inputs are optional
         tag_name: "v%s"
         tag_message: "v%s"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
     - name: Set up Node.js
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: 20
     - name: Publish if version has been updated

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,26 @@
 # Migration Guide
 
+## Upgrade from v7
+
+The JavaScript API is unchanged from v7 through v9 — no call-site changes. You need a native rebuild.
+
+1. Install the latest release:
+   ```bash
+   npm install react-native-zip-archive
+   ```
+   Expo: `npx expo install react-native-zip-archive`
+2. iOS: `cd ios && pod install`
+3. Android: rebuild the native app (a Metro reload is not enough).
+4. Verify `zip` / `unzip` (and password variants if you use them).
+5. Rollback if needed:
+   ```bash
+   npm install react-native-zip-archive@^7.0.0
+   ```
+
+Working examples: [playground-expo](./playground-expo/) and [playground-rn](./playground-rn/).
+
+Stay on v7 only for React Native **< 0.70**. On 0.70+, New Architecture is recommended. If the native module fails to load on an old-architecture 0.70+ app, fall back to v7 until Interop is confirmed.
+
 ## v9.2 / v9.3 / v9.4
 
 These releases add APIs and align iOS with Android. Most JavaScript call sites keep working; the notes below are the native/default changes that existing apps may observe.
@@ -20,9 +41,11 @@ Existing AES archives are unchanged; only newly created file-array zips on iOS p
 
 ### Other 9.2–9.4 notes
 
-- **9.2:** `cancel()` and stable `ErrorCodes` (`ERR_CANCELLED`, `ERR_WRONG_PASSWORD`, …).
+- **9.2:** `cancel()` and stable `ErrorCodes` (`ERR_CANCELLED`, `ERR_WRONG_PASSWORD`, …). iOS zip/unzip run on a background serial queue so `cancel()` is not blocked behind in-flight work (FIFO, same as Android’s single-thread executor).
 - **9.2:** Android `'STANDARD'` encryption is ZipCrypto (`ZIP_STANDARD`), not PKWARE Strong Encryption.
+- **9.3:** File-array `zip` / `zipWithPassword` apply `compressionLevel` on iOS (previously always `Z_DEFAULT_COMPRESSION`).
 - **9.4:** iOS `unzipAssets` reads from the app bundle; non-UTF-8 `charset` rejects with `ERR_UNSUPPORTED`; `getUncompressedSize` rejects on failure instead of resolving `-1`.
+- **9.4:** Empty directories are preserved on iOS when zipping directory items in a files array (already true on Android).
 
 ```bash
 npm install react-native-zip-archive@^9.4.0
@@ -43,7 +66,7 @@ v9.0 hardens the native implementations and aligns progress reporting across pla
 | `unzip` progress (iOS) | Effectively start/end events only | Byte-weighted, per-entry granularity |
 | `unzip` event `filePath` (iOS) | Full destination path | Zip entry name (e.g. `folder/file.txt`) |
 | `zip` progress with files array (iOS) | Only 0% and 100% events | Per-file progress events |
-| Concurrent operations (Android) | Ran in parallel | Serialized on a single worker thread |
+| Concurrent operations (Android) | Ran in parallel (one thread per call) | **Serialized FIFO** on a single-thread executor — concurrent zip/unzip calls queue; they do **not** run in parallel |
 | Malicious/traversal zip entries (Android) | Extracted outside destination | Rejected (Zip Slip protection) |
 
 ### Migration Steps
@@ -56,9 +79,14 @@ If you subscribe to `zipArchiveProgressEvent`:
 - **Don't assume the final 100% event arrives before the promise resolves.** On Android, events are now posted to the main thread and the last event may land after `.then()` runs. Gate completion logic on the promise, not the event.
 - Progress is byte-weighted per entry for `unzip`: with archives containing one very large file, expect the bar to jump rather than advance smoothly within that file.
 
-#### Step 2: Check concurrent usage (Android)
+#### Step 2: Check concurrent usage
 
-If you kick off multiple zip/unzip operations simultaneously, they now execute one at a time in call order. Await them sequentially, or expect later calls to take longer.
+If you kick off multiple zip/unzip operations simultaneously, they execute **one at a time in call order** (FIFO). They do not run in parallel.
+
+- **Android:** a single-thread executor (`Executors.newSingleThreadExecutor`). Later calls wait until earlier ones finish.
+- **iOS:** a background serial work queue (same FIFO behavior; this is what lets `cancel()` run).
+
+Await operations sequentially, or expect later calls to take longer because they are queued.
 
 #### Step 3: Rebuild
 
@@ -76,7 +104,7 @@ cd ios && pod install && cd ..
 
 ### What's Changed
 
-v8.0 migrates `react-native-zip-archive` from Legacy Native Modules to **TurboModules** (React Native New Architecture). This brings:
+v8.0 migrates `react-native-zip-archive` from Legacy Native Modules to **TurboModules**. This brings:
 - Better performance through lazy loading
 - Type safety via Codegen
 - Support for React 18 concurrent features
@@ -88,9 +116,11 @@ v8.0 migrates `react-native-zip-archive` from Legacy Native Modules to **TurboMo
 | React Native | >= 0.60.0 | >= 0.70.0 |
 | React | >= 16.8.6 | >= 18.0.0 |
 | Android API | >= 21 | >= 23 |
-| Architecture | Legacy | New Architecture (TurboModules) |
+| Architecture | Legacy Native Modules | TurboModules (New Architecture recommended) |
 
-**JavaScript API is unchanged.** No code changes needed in your app other than enabling New Architecture.
+**JavaScript API is unchanged.** No JavaScript call-site changes are required.
+
+Use v8+/v9 on React Native >= 0.70. Stay on v7 only if you are on React Native **< 0.70**. New Architecture is recommended; old-architecture Interop on 0.70+ is not confirmed — if the native module fails to load, fall back to v7 or enable New Architecture (see Troubleshooting).
 
 ### Migration Steps
 
@@ -100,11 +130,9 @@ v8.0 migrates `react-native-zip-archive` from Legacy Native Modules to **TurboMo
 npx react-native --version
 ```
 
-If you're on React Native < 0.70, you must either:
-- **Upgrade React Native** to 0.70+ (recommended)
-- **Stay on v7.x** of this library
+If you're on React Native < 0.70, stay on v7.x of this library (or upgrade React Native to 0.70+ first).
 
-#### Step 2: Enable New Architecture
+#### Step 2: New Architecture (recommended)
 
 Follow the [official React Native guide](https://reactnative.dev/docs/new-architecture-intro).
 
@@ -159,7 +187,7 @@ npm install react-native-zip-archive@^7.0.0
 
 | Issue | Solution |
 |-------|----------|
-| "Native module not found" | Ensure New Architecture is enabled in your app |
+| "Native module not found" | Enable New Architecture first. On an old-architecture 0.70+ app, fall back to `^7.0.0` until Interop is confirmed. |
 | Build fails on iOS | Delete `ios/Pods` and `ios/Podfile.lock`, then `pod install` |
 | Build fails on Android | Run `./gradlew clean` and clear Metro cache |
 | Works on Android but not iOS | Ensure you ran `RCT_NEW_ARCH_ENABLED=1 pod install` |
@@ -167,5 +195,5 @@ npm install react-native-zip-archive@^7.0.0
 
 ### Need Help?
 
-- Check the [playground app](./playground/) for working examples
+- Check [playground-expo](./playground-expo/) and [playground-rn](./playground-rn/) for working examples
 - Open an issue on GitHub

--- a/README.md
+++ b/README.md
@@ -2,10 +2,14 @@
 
 Zip archive utility for React Native.
 
-> **v8.0** requires React Native ≥ 0.70 with New Architecture enabled. For older RN versions, use v7.x:
+> Latest **v8+ / v9** targets React Native ≥ 0.70 with TurboModules. **New Architecture is recommended.**
+>
+> Use `^7.0.0` only if you are on React Native **< 0.70**:
 > ```bash
 > npm install react-native-zip-archive@^7.0.0
 > ```
+> If the native module fails to load on an old-architecture 0.70+ app, fall back to v7 until Interop Layer support is confirmed.
+>
 > **iOS:** Version 7.0.0+ requires a deployment target of iOS 15.5+ to comply with App Store privacy policy.
 
 ## Requirements
@@ -17,7 +21,22 @@ Zip archive utility for React Native.
 | iOS | >= 15.5 |
 | Android | >= API 23 (Android 6.0) |
 
+## Comparison
+
+| | This library | JSZip in React Native | Nitro (`react-native-nitro-unzip` / `react-native-nitro-archive`) |
+|---|---|---|---|
+| Zip / unzip | Native iOS + Android | Pure JS (not a native unzip) | Native via Nitro |
+| Password-protected zip | Yes | Fine for small in-memory archives | Check those packages |
+| Expo | Development builds / EAS (not Expo Go) | Can run in Expo Go | Native — needs a development build |
+| Extra native dependency | None beyond this package | None | `react-native-nitro-modules` |
+| Large files | Native I/O | Memory-heavy | Speed / extra-format claims |
+| Install base | Production RN apps | Very widely used as JS | Much smaller today |
+
+Use this library for native zip/unzip on device. Use JSZip when you only need small archives in JS. Nitro may fit if you want additional archive formats and accept the extra Nitro dependency and smaller install base.
+
 ## Installation
+
+### React Native (bare)
 
 ```bash
 npm install react-native-zip-archive
@@ -28,7 +47,27 @@ npm install react-native-zip-archive
 cd ios && pod install
 ```
 
-> To enable New Architecture, see [MIGRATION.md](./MIGRATION.md).
+New Architecture is recommended. See [MIGRATION.md](./MIGRATION.md).
+
+### Expo
+
+Works in **Expo development builds / EAS**. Does **not** work in Expo Go (this package includes custom native code).
+
+```bash
+npx expo install react-native-zip-archive
+```
+
+Add the config plugin in `app.json`:
+
+```json
+{
+  "expo": {
+    "plugins": ["react-native-zip-archive"]
+  }
+}
+```
+
+See [playground-expo](./playground-expo/) for a working Expo Development Build example.
 
 ## Usage
 
@@ -52,10 +91,18 @@ import {
 } from 'react-native-zip-archive'
 ```
 
-You may also want to use [react-native-fs](https://github.com/johanneslumpe/react-native-fs) to access the file system:
+**Bare React Native** — [react-native-fs](https://github.com/johanneslumpe/react-native-fs):
 
 ```js
 import { DocumentDirectoryPath } from 'react-native-fs'
+```
+
+**Expo** — [playground-expo](./playground-expo/) uses `expo-file-system/legacy`:
+
+```js
+import * as FileSystem from 'expo-file-system/legacy'
+
+const DocumentDirectoryPath = FileSystem.documentDirectory
 ```
 
 ## API
@@ -65,8 +112,8 @@ import { DocumentDirectoryPath } from 'react-native-fs'
 Zip a folder (string) or an array of files to the target path.
 
 - To zip a single file, pass it as an array: `zip([file], target)`.
-- Array items may also be directories: their contents are added recursively with entry paths relative to the listed directory (the directory's own name is not included). This behaves the same on Android and iOS, except that empty directories are preserved on Android only.
-- `compressionLevel` is ignored on iOS when the source is a file array. Use a directory source for custom compression on iOS.
+- Array items may also be directories: their contents are added recursively with entry paths relative to the listed directory (the directory's own name is not included). This behaves the same on Android and iOS. Empty directories are preserved on both platforms.
+- `compressionLevel` applies on both platforms for folder and file-array sources.
 
 **Compression Level Constants:**
 - `DEFAULT_COMPRESSION` (-1)
@@ -88,8 +135,8 @@ zip(sourcePath, targetPath)
 Zip with password protection.
 
 - To zip a single file, pass it as an array: `zipWithPassword([file], target, password)`.
-- Array items may also be directories: their contents are added recursively with entry paths relative to the listed directory (the directory's own name is not included). This behaves the same on Android and iOS, except that empty directories are preserved on Android only.
-- `compressionLevel` is ignored on iOS when the source is a file array.
+- Array items may also be directories: their contents are added recursively with entry paths relative to the listed directory (the directory's own name is not included). This behaves the same on Android and iOS. Empty directories are preserved on both platforms.
+- `compressionLevel` applies on both platforms for folder and file-array sources.
 
 **Encryption Types:**
 - `'STANDARD'` — Traditional ZIP encryption / ZipCrypto (default). This is **not** PKWARE Strong Encryption. On Android this writes zip4j `ZIP_STANDARD` so iOS and common unzip tools can decrypt the archive.
@@ -205,6 +252,8 @@ getUncompressedSize(sourcePath)
 
 Cancel the in-flight zip/unzip operation (best-effort). The active operation's promise rejects with `ErrorCodes.CANCELLED` (`ERR_CANCELLED`).
 
+Zip/unzip work is serialized. Android runs operations on a **single-thread executor**; concurrent calls queue FIFO and do not run in parallel. iOS uses a background serial queue similarly, so `cancel()` is not blocked behind the operation it is meant to stop.
+
 ```js
 const unzipPromise = unzip(sourcePath, targetPath)
 cancel()
@@ -264,10 +313,10 @@ useEffect(() => {
 
 | Feature | iOS | Android | Notes |
 |---------|-----|---------|-------|
-| `zip` (folder) | ✅ | ✅ | — |
-| `zip` (files array) | ✅ | ✅ | — |
+| `zip` (folder) | ✅ | ✅ | `compressionLevel` 0–9 |
+| `zip` (files array) | ✅ | ✅ | `compressionLevel` applies on both platforms |
 | `zipWithPassword` (folder) | ✅ | ✅ | Prefer `STANDARD` for server unzip |
-| `zipWithPassword` (files array) | ✅ | ✅ | iOS honors `STANDARD` vs AES |
+| `zipWithPassword` (files array) | ✅ | ✅ | iOS honors `STANDARD` vs AES; `compressionLevel` applies |
 | `unzip` | ✅ | ✅ | Optional `entries`; non-UTF-8 charset → `ERR_UNSUPPORTED` on iOS |
 | `unzipWithPassword` | ✅ | ✅ | Optional `entries` for selective extract |
 | `listContents` | ✅ | ✅ | Non-UTF-8 charset → `ERR_UNSUPPORTED` on iOS |
@@ -279,11 +328,12 @@ useEffect(() => {
 
 ### Cross-Platform Notes
 
-- **Compression levels:** Android supports 0–9 for all operations. iOS supports 0–9 for folder and file-array zips.
+- **Compression levels:** Android and iOS apply `compressionLevel` (0–9) for folder and file-array `zip` / `zipWithPassword`.
 - **Encryption:** Android supports AES-128, AES-256, and Standard ZIP encryption for all operations. On iOS, pass `'STANDARD'` (default) for ZipCrypto archives that Node `unzipper` / Java `ZipInputStream` can read; `'AES-128'` / `'AES-256'` produce WinZip-AES archives that many server tools cannot open.
 - **Charset:** Android supports custom charsets (default UTF-8). iOS accepts only UTF-8; other values reject with `ERR_UNSUPPORTED`.
 - **unzipAssets:** Android reads `assets/` (and `content://`). iOS reads from the main app bundle using the same relative path.
 - **Empty directories:** Preserved when zipping directory contents via a files/folders array on both platforms.
+- **Concurrent operations:** Android zip/unzip run on a single-thread executor; concurrent calls queue FIFO and do not run in parallel. iOS uses a background serial queue similarly (so `cancel()` is not blocked behind in-flight work).
 
 ### Server-side unzip interoperability
 
@@ -300,7 +350,7 @@ node scripts/validate-zip-header.js /path/to/archive.zip
 
 ## Expo
 
-This library **requires an Expo Development Build** and does not work in Expo Go because it includes custom native code. See [playground-expo](./playground-expo/) for a working Expo Development Build example.
+Works in Expo development builds / EAS only — not Expo Go. Install and plugin setup are under [Installation](#installation). See [playground-expo](./playground-expo/) for a working example.
 
 ## Playground
 
@@ -313,7 +363,11 @@ Both apps consume the local library via `file:..` and include Maestro E2E tests.
 
 ## Migrating
 
-See [MIGRATION.md](./MIGRATION.md) for v7 → v8, v8 → v9.0, and v9.2–v9.4 notes.
+Coming from v7? Start with [Upgrade from v7](./MIGRATION.md#upgrade-from-v7). See [MIGRATION.md](./MIGRATION.md) for v7 → v8, v8 → v9.0, and v9.2–v9.4 notes.
+
+## Security
+
+See [SECURITY.md](./SECURITY.md) for supported versions and how to report vulnerabilities.
 
 ## Testing
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,36 @@
+# Security Policy
+
+## Supported versions
+
+| Version | Support |
+| --- | --- |
+| **9.x** (latest) | Actively supported |
+| **8.x** | Not patched. Upgrade to 9.x — the JS API is compatible |
+| **7.x** | Security fixes only through **2027-02-19**. After that, 7.x is unsupported. Stay on 7.x if you are on React Native &lt; 0.70 until you upgrade RN. 7.x will not be deleted or unpublished. |
+| **&lt; 7** | Unsupported except for critical issues |
+
+Zip Slip / symlink fixes shipped in 9.x will be **evaluated for 7.x backports**. If a patch is warranted, it will be published as `7.x.y`. Those backports are not done yet.
+
+## Reporting a vulnerability
+
+Prefer [GitHub Security Advisories](https://github.com/mockingbot/react-native-zip-archive/security/advisories/new).
+
+You can also email the maintainer: **Perry Poon** &lt;plrthink@gmail.com&gt;.
+
+Please **do not** file a public GitHub issue for an unfixed vulnerability.
+
+## Scope
+
+In scope:
+
+- Zip Slip / path traversal on extract
+- Symlink extract that resolves outside the destination directory
+- Password / crypto issues in zip/unzip
+- Supply-chain issues in native deps (**SSZipArchive** on iOS, **zip4j** on Android)
+
+### What already landed in 9.x
+
+- **Android Zip Slip** protection: 9.0.0 — extract rejects entries whose path escapes the destination.
+- **Android symlink extract**: 9.0.2 — `unzip` / `unzipWithPassword` no longer materialize symlink entries.
+
+iOS (verified in `ios/RNZipArchive.mm`): selective extract rejects Zip Slip via `isSafeExtractPath`. Full unzip goes through SSZipArchive; this policy does not claim extra checks there. `ios/` does not skip symlink entries.

--- a/__tests__/expo-plugin.test.js
+++ b/__tests__/expo-plugin.test.js
@@ -9,8 +9,8 @@ describe('Expo config plugin (RNZA-10)', () => {
     expect(typeof plugin).toBe('function');
   });
 
-  test('package.json points Expo at ./app.plugin.js', () => {
-    expect(pkg.expo).toEqual({ plugin: './app.plugin.js' });
+  test('ships app.plugin.js at the package root (Expo resolution order)', () => {
+    expect(pkg.expo).toBeUndefined();
     expect(fs.existsSync(path.join(__dirname, '..', 'app.plugin.js'))).toBe(true);
   });
 

--- a/__tests__/expo-plugin.test.js
+++ b/__tests__/expo-plugin.test.js
@@ -1,0 +1,34 @@
+const path = require('path');
+const fs = require('fs');
+
+const plugin = require('../app.plugin.js');
+const pkg = require('../package.json');
+
+describe('Expo config plugin (RNZA-10)', () => {
+  test('is a CommonJS function Expo can load without @expo/config-plugins', () => {
+    expect(typeof plugin).toBe('function');
+  });
+
+  test('package.json points Expo at ./app.plugin.js', () => {
+    expect(pkg.expo).toEqual({ plugin: './app.plugin.js' });
+    expect(fs.existsSync(path.join(__dirname, '..', 'app.plugin.js'))).toBe(true);
+  });
+
+  test('is a no-op: returns the same config object', () => {
+    const config = {
+      name: 'Demo',
+      slug: 'demo',
+      plugins: ['expo-router', 'react-native-zip-archive'],
+      ios: { bundleIdentifier: 'com.demo' },
+      android: { package: 'com.demo' },
+    };
+    const result = plugin(config);
+    expect(result).toBe(config);
+    expect(result.plugins).toEqual(['expo-router', 'react-native-zip-archive']);
+  });
+
+  test('does not throw on an empty Expo config', () => {
+    expect(() => plugin({})).not.toThrow();
+    expect(plugin({})).toEqual({});
+  });
+});

--- a/__tests__/package-metadata.test.js
+++ b/__tests__/package-metadata.test.js
@@ -1,0 +1,78 @@
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const pkg = require('../package.json');
+
+describe('npm listing (RNZA-13) and packed files', () => {
+  test('description names zip/unzip, React Native, Expo, and both platforms', () => {
+    expect(pkg.description).toBe(
+      'Zip and unzip files in React Native and Expo (iOS & Android)'
+    );
+  });
+
+  test('keywords include expo, eas, password, aes, and turbo-module', () => {
+    for (const keyword of ['expo', 'eas', 'password', 'aes', 'turbo-module', 'unzip']) {
+      expect(pkg.keywords).toContain(keyword);
+    }
+  });
+
+  test('npm pack includes the Expo plugin and SECURITY.md', () => {
+    const packed = spawnSync('npm', ['pack', '--dry-run', '--json'], {
+      cwd: path.join(__dirname, '..'),
+      encoding: 'utf8',
+    });
+    expect(packed.status).toBe(0);
+    const parsed = JSON.parse(packed.stdout);
+    const files = parsed[0].files.map((f) => f.path);
+    expect(files).toContain('app.plugin.js');
+    expect(files).toContain('SECURITY.md');
+    expect(files).toContain('package.json');
+    expect(files).toContain('README.md');
+    expect(files).not.toContain('playground-expo/app.json');
+  });
+});
+
+describe('docs claims vs native source (RNZA-7/15/17/19)', () => {
+  const read = (rel) => fs.readFileSync(path.join(__dirname, '..', rel), 'utf8');
+
+  test('JS still falls back from TurboModuleRegistry to NativeModules', () => {
+    const index = read('index.js');
+    expect(index).toMatch(/TurboModuleRegistry\.get\("RNZipArchive"\)/);
+    expect(index).toMatch(/NativeModules\.RNZipArchive/);
+  });
+
+  test('Android zip/unzip still serialize on a single-thread executor', () => {
+    expect(read('android/src/main/java/com/rnziparchive/RNZipArchiveModule.java')).toMatch(
+      /Executors\.newSingleThreadExecutor/
+    );
+  });
+
+  test('iOS preserves empty child directories in a files-array zip', () => {
+    const mm = read('ios/RNZipArchive.mm');
+    expect(mm).toMatch(/Empty directories are preserved as directory entries/);
+    expect(mm).toMatch(/writeFolderAtPath/);
+  });
+
+  test('iOS file-array zip applies compressionLevel', () => {
+    const mm = read('ios/RNZipArchive.mm');
+    expect(mm).toMatch(/compressionLevel:compressionLevel/);
+    expect(mm).toMatch(/zlibCompressionLevel/);
+  });
+
+  test('SECURITY.md matches the Android Zip Slip / symlink helpers that exist', () => {
+    const security = read('SECURITY.md');
+    const zipSecurity = read('android/src/main/java/com/rnziparchive/ZipSecurity.java');
+    expect(security).toMatch(/9\.x/);
+    expect(security).toMatch(/2027-02-19/);
+    expect(zipSecurity).toMatch(/setExtractSymbolicLinks\(false\)/);
+    expect(zipSecurity).toMatch(/Zip Path Traversal Vulnerability/);
+    expect(read('ios/RNZipArchive.mm')).toMatch(/isSafeExtractPath/);
+  });
+
+  test('README does not claim old-arch Interop is proven', () => {
+    const readme = read('README.md');
+    expect(readme).toMatch(/old-architecture 0\.70\+ app/);
+    expect(readme).not.toMatch(/old architecture is (fully )?supported/i);
+  });
+});

--- a/app.plugin.js
+++ b/app.plugin.js
@@ -1,0 +1,3 @@
+module.exports = function withReactNativeZipArchive(config) {
+  return config
+}

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,6 +1,6 @@
 # End-to-End Testing
 
-This directory contains end-to-end (E2E) tests for the `react-native-zip-archive` playground app.
+This directory contains end-to-end (E2E) tests for the `react-native-zip-archive` playground apps (`playground-expo` and `playground-rn`). The Maestro flows live in `.maestro/flows/` at the repo root.
 
 ## Test Framework: Maestro
 
@@ -26,9 +26,9 @@ For other platforms, see the [Maestro installation guide](https://maestro.mobile
 
 ### iOS Simulator
 
-1. Build the iOS app:
+1. Build the iOS app (Expo playground shown; for the bare RN app use `playground-rn/ios` and `PlaygroundRN`):
    ```bash
-   cd playground/ios
+   cd playground-expo/ios
    xcodebuild -workspace RNZipArchivePlayground.xcworkspace \
      -scheme RNZipArchivePlayground \
      -configuration Debug \
@@ -45,7 +45,7 @@ For other platforms, see the [Maestro installation guide](https://maestro.mobile
 
 1. Build the Android app:
    ```bash
-   cd playground/android
+   cd playground-expo/android
    ./gradlew :app:assembleDebug
    ```
 
@@ -73,7 +73,7 @@ Maestro flows are YAML files that describe user interactions. See the [Maestro d
 
 Example:
 ```yaml
-appId: com.example.rnziparchive.playground
+appId: com.rnziparchive.playground.expo
 ---
 - launchApp
 - tapOn: "Zip Operations"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-zip-archive",
   "version": "9.4.0",
-  "description": "A TurboModule wrapper on ZipArchive for React Native's New Architecture",
+  "description": "Zip and unzip files in React Native and Expo (iOS & Android)",
   "main": "index.js",
   "scripts": {
     "test": "jest",
@@ -25,7 +25,12 @@
     "zip",
     "archive",
     "zip-archive",
-    "unzip"
+    "unzip",
+    "expo",
+    "eas",
+    "password",
+    "aes",
+    "turbo-module"
   ],
   "author": "Perry Poon <plrthink@gmail.com> (https://github.com/plrthink)",
   "homepage": "https://github.com/mockingbot/react-native-zip-archive",
@@ -52,6 +57,9 @@
   "peerDependencies": {
     "react": ">=18.0.0",
     "react-native": ">=0.70.0"
+  },
+  "expo": {
+    "plugin": "./app.plugin.js"
   },
   "codegenConfig": {
     "name": "NativeZipArchiveSpec",

--- a/package.json
+++ b/package.json
@@ -58,9 +58,6 @@
     "react": ">=18.0.0",
     "react-native": ">=0.70.0"
   },
-  "expo": {
-    "plugin": "./app.plugin.js"
-  },
   "codegenConfig": {
     "name": "NativeZipArchiveSpec",
     "type": "modules",

--- a/playground-expo/README.md
+++ b/playground-expo/README.md
@@ -6,7 +6,7 @@
 
 ### 1. Install dependencies
 ```bash
-cd playground
+cd playground-expo
 npm install
 ```
 

--- a/playground-expo/app.json
+++ b/playground-expo/app.json
@@ -18,7 +18,8 @@
       "package": "com.rnziparchive.playground.expo"
     },
     "plugins": [
-      "expo-router"
+      "expo-router",
+      "react-native-zip-archive"
     ],
     "scheme": "rnziparchive",
     "newArchEnabled": true


### PR DESCRIPTION
## Summary

Ships the P0/P1/P2 growth work that does not need device hardware.

- v7 banner rewrite: latest v9 for RN ≥ 0.70; `^7` only for RN < 0.70
- Upgrade-from-v7 note, Expo install path + no-op config plugin
- npm description/keywords, JSZip/Nitro comparison
- SECURITY.md (7.x security-only through 2027-02-19; Zip Slip backports not done)
- SHA-pinned GitHub Actions

## Test plan

- [x] `npm test` (49)
- [x] Expo plugin resolves from packed `app.plugin.js`
- [x] ZipSecurity JUnit 7/7
- [ ] CI on this PR

Not in this PR: RNZA-5 old-arch matrix, RNZA-6 Interop, RNZA-16, RNZA-20.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mockingbot/react-native-zip-archive/pull/374" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->