### PR TITLE
Release 9.4.1 to npm

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,9 @@ name: npm-publish
 on:
   push:
     branches:
-      - master # Change this to your default branch
+      - master
+      - 7.x
+  workflow_dispatch:
 jobs:
   npm-publish:
     name: npm-publish
@@ -14,12 +16,15 @@ jobs:
       uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: 20
+        registry-url: https://registry.npmjs.org
     - name: Publish if version has been updated
       uses: pascalgn/npm-publish-action@374314eadce0ca5353387666469a949f69414752 # 1.3.9
-      with: # All of theses inputs are optional
+      with:
         tag_name: "v%s"
         tag_message: "v%s"
         commit_pattern: "^Release (\\S+)"
-      env: # More info about the environment variables in the README
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Leave this as is, it's automatically generated
-        NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }} # You need to set this in your repo settings
+        publish_command: "npm"
+        publish_args: "publish --access public"
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Publishes **9.4.1** (already merged in #376) to npm.

## Changes
- Fix `npm-publish` workflow: use `npm publish` (was defaulting to `yarn`), add `workflow_dispatch`, and include `7.x` branch
- Empty commit `Release 9.4.1` to satisfy the publish action's commit pattern

## Maintainer action required
The **npm-publish** workflow is currently **disabled** in GitHub Actions. After merging:
1. Re-enable **npm-publish** under Actions → Workflows
2. Confirm `NPM_AUTH_TOKEN` is set in repo secrets
3. The push from this merge should publish 9.4.1 automatically; or run the workflow manually via **workflow_dispatch**
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a04cf9-2ea9-7b7c-bea2-2b7578fe0f19?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a04cf9-2ea9-7b7c-bea2-2b7578fe0f19&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

