### PR TITLE
fix(ci): npm pack test + v7 dist-tag for publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -86,9 +86,21 @@ jobs:
             echo "Version ${VERSION} is not on npm yet — will publish."
           fi
 
+      - name: Determine npm dist-tag
+        id: dist_tag
+        run: |
+          MAJOR=$(node -p "require('./package.json').version.split('.')[0]")
+          if [ "$MAJOR" = "7" ]; then
+            echo "tag=v7" >> "$GITHUB_OUTPUT"
+            echo "Using dist-tag v7 (maintenance line; latest remains 9.x)."
+          else
+            echo "tag=latest" >> "$GITHUB_OUTPUT"
+            echo "Using dist-tag latest."
+          fi
+
       - name: Publish to npm
         if: steps.npm_version.outputs.published != 'true'
-        run: npm publish --access public
+        run: npm publish --access public --tag ${{ steps.dist_tag.outputs.tag }}
         env:
           # When unset, npm 11.5+ uses OIDC if Trusted Publisher is configured.
           # When set, uses classic token auth instead.

--- a/__tests__/package-metadata.test.js
+++ b/__tests__/package-metadata.test.js
@@ -24,7 +24,11 @@ describe('npm listing (RNZA-13) and packed files', () => {
     });
     expect(packed.status).toBe(0);
     const parsed = JSON.parse(packed.stdout);
-    const files = parsed[0].files.map((f) => f.path);
+    const packMeta = Array.isArray(parsed)
+      ? parsed[0]
+      : parsed[pkg.name] ?? Object.values(parsed)[0];
+    expect(packMeta?.files).toBeDefined();
+    const files = packMeta.files.map((f) => f.path);
     expect(files).toContain('app.plugin.js');
     expect(files).toContain('SECURITY.md');
     expect(files).toContain('package.json');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes tag-triggered publish failures after #380:

1. **9.4.1** — `npm pack --json` on npm@latest returns an object keyed by package name, not an array. Update test to accept both shapes.
2. **7.1.2** — npm refuses to apply `latest` when publishing 7.1.2 because 9.4.0 is higher. Publish 7.x with `--tag v7` instead.

After merge, retag `v9.4.1` and `v7.1.2` to re-run publish.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a04cf9-2ea9-7b7c-bea2-2b7578fe0f19?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a04cf9-2ea9-7b7c-bea2-2b7578fe0f19&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

