### PR TITLE
fix(ci): rename v7 dist-tag to maintenance-7

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -91,8 +91,8 @@ jobs:
         run: |
           MAJOR=$(node -p "require('./package.json').version.split('.')[0]")
           if [ "$MAJOR" = "7" ]; then
-            echo "tag=v7" >> "$GITHUB_OUTPUT"
-            echo "Using dist-tag v7 (maintenance line; latest remains 9.x)."
+            echo "tag=maintenance-7" >> "$GITHUB_OUTPUT"
+            echo "Using dist-tag maintenance-7 (7.x line; latest remains 9.x)."
           else
             echo "tag=latest" >> "$GITHUB_OUTPUT"
             echo "Using dist-tag latest."


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #381: npm rejects `v7` as a dist-tag because it parses as a SemVer range. 7.1.2 publish succeeded with `maintenance-7` (already on `7.x`); this aligns `master` for future 7.x tag publishes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a04cf9-2ea9-7b7c-bea2-2b7578fe0f19?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a04cf9-2ea9-7b7c-bea2-2b7578fe0f19&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

