### PR TITLE
chore(release): v9.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,16 @@
 
 ## [Unreleased]
 
+## [9.5.0] - 2026-09-04
+
 ### Added
-- CI + npm publish gate: non-password zip fixtures must extract with Node `unzipper` and Java `ZipInputStream`; WinZip-AES extra field `0x9901` fails the job (RNZA-16, #333 / #323 class)
-- `AbortSignal` on `zip` / `zipWithPassword` / `unzip` / `unzipWithPassword` / `unzipAssets` via an options object (`{ signal, compressionLevel?, entries? }`)
-- `ZipError` with a stable `.code` (`ERR_CANCELLED`, `ERR_INVALID_ARGS`, …) — implemented as a factory so Metro does not need `@babel/runtime` helpers when bundling the library
-- `package.json` `"types": "index.d.ts"` so TypeScript and reactnative.directory `hasTypes` resolve
+- CI + npm publish gate: non-password zip fixtures must extract with Node `unzipper` and Java `ZipInputStream`; WinZip-AES extra field `0x9901` fails the job (#383, RNZA-16, #333 / #323 class)
+- `AbortSignal` on `zip` / `zipWithPassword` / `unzip` / `unzipWithPassword` / `unzipAssets` via an options object (`{ signal, compressionLevel?, entries? }`) (#383)
+- `ZipError` with a stable `.code` (`ERR_CANCELLED`, `ERR_INVALID_ARGS`, …) — implemented as a factory so Metro does not need `@babel/runtime` helpers when bundling the library (#383)
+- `package.json` `"types": "index.d.ts"` so TypeScript and reactnative.directory `hasTypes` resolve (#383)
 
 ### Changed
-- SECURITY.md: 7.x Zip Slip / symlink backport is **7.1.2** (`maintenance-7`), not 7.1.1
+- SECURITY.md: 7.x Zip Slip / symlink backport is **7.1.2** (`maintenance-7`), not 7.1.1 (#383)
 
 ## [9.4.1] - 2026-08-29
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -21,6 +21,19 @@ Working examples: [playground-expo](./playground-expo/) and [playground-rn](./pl
 
 Stay on v7 only for React Native **< 0.70**. On 0.70+, New Architecture is recommended. If the native module fails to load on an old-architecture 0.70+ app, fall back to v7 until Interop is confirmed.
 
+## v9.5
+
+Additive JavaScript APIs. Existing positional `zip` / `unzip` calls are unchanged.
+
+- **`AbortSignal`:** pass `{ signal }` as the last argument to `zip` / `zipWithPassword` / `unzip` / `unzipWithPassword` / `unzipAssets` to cancel. Rejects with `ZipError` code `ERR_CANCELLED`.
+- **`ZipError`:** factory (not an ES `class`) with a stable `.code`. Check `error.code`; do not use `instanceof ZipError`.
+- **TypeScript:** `package.json` `"types"` points at `index.d.ts`.
+
+```bash
+npm install react-native-zip-archive@^9.5.0
+cd ios && pod install && cd ..
+```
+
 ## v9.2 / v9.3 / v9.4
 
 These releases add APIs and align iOS with Android. Most JavaScript call sites keep working; the notes below are the native/default changes that existing apps may observe.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-zip-archive",
-  "version": "9.4.1",
+  "version": "9.5.0",
   "description": "Zip and unzip files in React Native and Expo (iOS & Android)",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Targets **latest** (`master` / 9.x). Publishes **9.5.0** as `latest` (9.4.1 is already on npm).

## Why this version

#383 already landed. npm still serves 9.4.1, so this bump is required before `publish.yml` will upload anything new.

**9.5.0** is a minor: `AbortSignal`, `ZipError`, published TypeScript types, zip-interop publish gate.

## Publish

`v9.5.0` is tagged on this commit so **Actions → Publish to npm** runs (`latest` dist-tag). GitHub Release is created by the same workflow.

v7 is unchanged (`maintenance-7` stays 7.1.2).

## Test plan

- [x] `npm test` (64 passing)
- [x] `npm run test:interop`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8b7a154b-c14e-496a-b71a-2d6249bc233d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8b7a154b-c14e-496a-b71a-2d6249bc233d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

