### PR TITLE
chore(release): v9.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 ## [Unreleased]
 
+## [9.5.1] - 2026-09-05
+
 ### Fixed
-- Android: register as a legacy Native Module when New Architecture is off (`isTurboModule` follows `BuildConfig.IS_NEW_ARCHITECTURE_ENABLED`) so `NativeModules.RNZipArchive` is non-null on old-arch apps (RNZA-5)
+- Android: register as a legacy Native Module when New Architecture is off (`isTurboModule` follows `BuildConfig.IS_NEW_ARCHITECTURE_ENABLED`) so `NativeModules.RNZipArchive` is non-null on old-arch apps (RNZA-5, #385)
 
 ### Added
 - CI: RN 0.81.6 old-architecture Android + iOS compile in `.github/workflows/old-arch.yml` (RNZA-5). RN 0.82+ cannot opt out of New Architecture.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -27,6 +27,17 @@ Working examples: [playground-expo](./playground-expo/) and [playground-rn](./pl
 
 Old-arch proof is compile + link on RN **0.81.6** (`.github/workflows/old-arch.yml`), not device Maestro. See the [README matrix](./README.md#old-architecture-rn-070081).
 
+## v9.5.1
+
+Android old-architecture load fix. JavaScript call sites are unchanged. Native rebuild required.
+
+```bash
+npm install react-native-zip-archive@^9.5.1
+cd ios && pod install && cd ..
+```
+
+Stay on `^7.0.0` only for RN **< 0.70**. On 0.70–0.81, old architecture works. On 0.82+, New Architecture is the only option.
+
 ## v9.5
 
 Additive JavaScript APIs. Existing positional `zip` / `unzip` calls are unchanged.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-zip-archive",
-  "version": "9.5.0",
+  "version": "9.5.1",
   "description": "Zip and unzip files in React Native and Expo (iOS & Android)",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Targets **latest** (`master` / 9.x). Publishes **9.5.1** as `latest`.

## Why this version

#385 landed. npm still serves 9.5.0, so this bump is required before `publish.yml` uploads the old-arch Android load fix.

**9.5.1** is a patch: Android `isTurboModule` follows `BuildConfig.IS_NEW_ARCHITECTURE_ENABLED`; install table (v7 only for RN < 0.70).

## Publish

`v9.5.1` is tagged on this commit so **Actions → Publish to npm** runs (`latest` dist-tag). GitHub Release is created by the same workflow.

v7 is unchanged (`maintenance-7` stays 7.1.2).

## Test plan

- [x] `npm test` (64 passing)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4dd63715-7a43-43b2-b51e-244af4ce9f94?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4dd63715-7a43-43b2-b51e-244af4ce9f94&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

